### PR TITLE
feat: 設定ページ実装（継続達成セット数・デフォルトセット数・重量単位）

### DIFF
--- a/src/hooks/useSettings.test.ts
+++ b/src/hooks/useSettings.test.ts
@@ -1,0 +1,79 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useSettings } from './useSettings'
+
+const STORAGE_KEY = 'strength-log-settings'
+
+describe('useSettings', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('初期値: defaultSets=3, trainingDefaultSets=3, weightUnit="kg" が返る', () => {
+    const { result } = renderHook(() => useSettings())
+    expect(result.current.settings.defaultSets).toBe(3)
+    expect(result.current.settings.trainingDefaultSets).toBe(3)
+    expect(result.current.settings.weightUnit).toBe('kg')
+  })
+
+  it('updateDefaultSets(5) で settings.defaultSets が 5 になる', () => {
+    const { result } = renderHook(() => useSettings())
+    act(() => {
+      result.current.updateDefaultSets(5)
+    })
+    expect(result.current.settings.defaultSets).toBe(5)
+  })
+
+  it('updateDefaultSets で localStorage に保存される', () => {
+    const { result } = renderHook(() => useSettings())
+    act(() => {
+      result.current.updateDefaultSets(7)
+    })
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+    expect(stored.defaultSets).toBe(7)
+  })
+
+  it('updateTrainingDefaultSets(4) で settings.trainingDefaultSets が 4 になる', () => {
+    const { result } = renderHook(() => useSettings())
+    act(() => {
+      result.current.updateTrainingDefaultSets(4)
+    })
+    expect(result.current.settings.trainingDefaultSets).toBe(4)
+  })
+
+  it('updateTrainingDefaultSets で localStorage に保存される', () => {
+    const { result } = renderHook(() => useSettings())
+    act(() => {
+      result.current.updateTrainingDefaultSets(4)
+    })
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+    expect(stored.trainingDefaultSets).toBe(4)
+  })
+
+  it('updateWeightUnit("lbs") で settings.weightUnit が "lbs" になる', () => {
+    const { result } = renderHook(() => useSettings())
+    act(() => {
+      result.current.updateWeightUnit('lbs')
+    })
+    expect(result.current.settings.weightUnit).toBe('lbs')
+  })
+
+  it('updateWeightUnit で localStorage に保存される', () => {
+    const { result } = renderHook(() => useSettings())
+    act(() => {
+      result.current.updateWeightUnit('lbs')
+    })
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+    expect(stored.weightUnit).toBe('lbs')
+  })
+
+  it('localStorage に既存値があれば読み込む', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ defaultSets: 5, weightUnit: 'lbs' })
+    )
+    const { result } = renderHook(() => useSettings())
+    expect(result.current.settings.defaultSets).toBe(5)
+    expect(result.current.settings.weightUnit).toBe('lbs')
+  })
+})

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import type { Settings } from '../types'
+
+const STORAGE_KEY = 'strength-log-settings'
+
+const DEFAULT_SETTINGS: Settings = {
+  defaultSets: 3,
+  trainingDefaultSets: 3,
+  weightUnit: 'kg',
+}
+
+function loadSettings(): Settings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_SETTINGS
+    return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) }
+  } catch {
+    return DEFAULT_SETTINGS
+  }
+}
+
+function saveSettings(settings: Settings): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+}
+
+export function useSettings() {
+  const [settings, setSettings] = useState<Settings>(loadSettings)
+
+  function updateDefaultSets(n: number) {
+    setSettings((prev) => {
+      const next = { ...prev, defaultSets: n }
+      saveSettings(next)
+      return next
+    })
+  }
+
+  function updateTrainingDefaultSets(n: number) {
+    setSettings((prev) => {
+      const next = { ...prev, trainingDefaultSets: n }
+      saveSettings(next)
+      return next
+    })
+  }
+
+  function updateWeightUnit(unit: 'kg' | 'lbs') {
+    setSettings((prev) => {
+      const next = { ...prev, weightUnit: unit }
+      saveSettings(next)
+      return next
+    })
+  }
+
+  return { settings, updateDefaultSets, updateTrainingDefaultSets, updateWeightUnit }
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,6 +4,7 @@ import Calendar from '../components/Calendar/Calendar'
 import ContinuityGauge from '../components/ContinuityGauge/ContinuityGauge'
 import TrophyBadge from '../components/TrophyBadge/TrophyBadge'
 import type { TrophyRecord } from '../components/TrophyBadge/TrophyBadge'
+import { useSettings } from '../hooks/useSettings'
 
 // TODO: 記録機能実装後に実データに置き換える
 const MOCK_TROPHIES: TrophyRecord[] = [
@@ -21,6 +22,7 @@ const STAGE_SAMPLES = [
 ]
 
 export default function HomePage() {
+  const { settings } = useSettings()
   const [currentDate, setCurrentDate] = useState(new Date())
   const [selectedDate, setSelectedDate] = useState<Date | null>(null)
   const [previewGauge, setPreviewGauge] = useState(10)
@@ -65,7 +67,7 @@ export default function HomePage() {
 
       <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <ContinuityGauge current={previewGauge} />
+          <ContinuityGauge current={previewGauge} requiredSets={settings.defaultSets} />
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
           <TrophyBadge trophies={MOCK_TROPHIES} />

--- a/src/pages/SettingsPage.module.css
+++ b/src/pages/SettingsPage.module.css
@@ -1,0 +1,83 @@
+.page {
+  padding: 1.5rem 1rem;
+}
+
+.section {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.25rem 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.sectionTitle {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-gray);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 0;
+}
+
+.row + .row {
+  border-top: 1px solid #f3f4f6;
+}
+
+.label {
+  font-size: 1rem;
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.select {
+  appearance: none;
+  background-color: var(--color-bg);
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.4rem 2rem 0.4rem 0.75rem;
+  font-size: 1rem;
+  font-family: inherit;
+  color: var(--color-text);
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%239ca3af' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.6rem center;
+}
+
+.select:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.toggle {
+  display: flex;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.toggleButton {
+  padding: 0.4rem 1rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+  background: #fff;
+  border: none;
+  color: var(--color-gray);
+  font-weight: 500;
+  transition: background 0.15s, color 0.15s;
+}
+
+.toggleButton + .toggleButton {
+  border-left: 1px solid #e5e7eb;
+}
+
+.toggleButton.active {
+  background: var(--color-primary);
+  color: #fff;
+}

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import SettingsPage from './SettingsPage'
+
+const mockUpdateDefaultSets = vi.fn()
+const mockUpdateTrainingDefaultSets = vi.fn()
+const mockUpdateWeightUnit = vi.fn()
+
+vi.mock('../hooks/useSettings', () => ({
+  useSettings: () => ({
+    settings: { defaultSets: 3, trainingDefaultSets: 3, weightUnit: 'kg' },
+    updateDefaultSets: mockUpdateDefaultSets,
+    updateTrainingDefaultSets: mockUpdateTrainingDefaultSets,
+    updateWeightUnit: mockUpdateWeightUnit,
+  }),
+}))
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('「継続達成セット数」ラベルが表示される', () => {
+    render(<SettingsPage />)
+    expect(screen.getByText('継続達成セット数')).toBeInTheDocument()
+  })
+
+  it('「デフォルトセット数」ラベルが表示される', () => {
+    render(<SettingsPage />)
+    expect(screen.getByText('デフォルトセット数')).toBeInTheDocument()
+  })
+
+  it('「重量単位」ラベルが表示される', () => {
+    render(<SettingsPage />)
+    expect(screen.getByText('重量単位')).toBeInTheDocument()
+  })
+
+  it('両selectが1〜10の選択肢を持つ', () => {
+    render(<SettingsPage />)
+    const selects = screen.getAllByRole('combobox')
+    expect(selects).toHaveLength(2)
+    selects.forEach((select) => {
+      const options = Array.from((select as HTMLSelectElement).options).map(
+        (o) => Number(o.value)
+      )
+      expect(options).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    })
+  })
+
+  it('継続達成セット数selectの変更でupdateDefaultSetsが呼ばれる', async () => {
+    render(<SettingsPage />)
+    const selects = screen.getAllByRole('combobox')
+    await userEvent.selectOptions(selects[0], '5')
+    expect(mockUpdateDefaultSets).toHaveBeenCalledWith(5)
+  })
+
+  it('デフォルトセット数selectの変更でupdateTrainingDefaultSetsが呼ばれる', async () => {
+    render(<SettingsPage />)
+    const selects = screen.getAllByRole('combobox')
+    await userEvent.selectOptions(selects[1], '4')
+    expect(mockUpdateTrainingDefaultSets).toHaveBeenCalledWith(4)
+  })
+
+  it('kg・lbsボタンが表示される', () => {
+    render(<SettingsPage />)
+    expect(screen.getByRole('button', { name: 'kg' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'lbs' })).toBeInTheDocument()
+  })
+
+  it('kgボタンクリックでupdateWeightUnit("kg")が呼ばれる', async () => {
+    render(<SettingsPage />)
+    await userEvent.click(screen.getByRole('button', { name: 'kg' }))
+    expect(mockUpdateWeightUnit).toHaveBeenCalledWith('kg')
+  })
+
+  it('lbsボタンクリックでupdateWeightUnit("lbs")が呼ばれる', async () => {
+    render(<SettingsPage />)
+    await userEvent.click(screen.getByRole('button', { name: 'lbs' }))
+    expect(mockUpdateWeightUnit).toHaveBeenCalledWith('lbs')
+  })
+})

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,3 +1,62 @@
+import { useSettings } from '../hooks/useSettings'
+import styles from './SettingsPage.module.css'
+
 export default function SettingsPage() {
-  return <div style={{ padding: '1rem' }}>設定（準備中）</div>
+  const { settings, updateDefaultSets, updateTrainingDefaultSets, updateWeightUnit } = useSettings()
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.section}>
+        <p className={styles.sectionTitle}>記録設定</p>
+
+        <div className={styles.row}>
+          <span className={styles.label}>継続達成セット数</span>
+          <select
+            className={styles.select}
+            value={settings.defaultSets}
+            onChange={(e) => updateDefaultSets(Number(e.target.value))}
+          >
+            {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.row}>
+          <span className={styles.label}>デフォルトセット数</span>
+          <select
+            className={styles.select}
+            value={settings.trainingDefaultSets}
+            onChange={(e) => updateTrainingDefaultSets(Number(e.target.value))}
+          >
+            {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.row}>
+          <span className={styles.label}>重量単位</span>
+          <div className={styles.toggle}>
+            <button
+              className={`${styles.toggleButton} ${settings.weightUnit === 'kg' ? styles.active : ''}`}
+              onClick={() => updateWeightUnit('kg')}
+            >
+              kg
+            </button>
+            <button
+              className={`${styles.toggleButton} ${settings.weightUnit === 'lbs' ? styles.active : ''}`}
+              onClick={() => updateWeightUnit('lbs')}
+            >
+              lbs
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,11 @@
 export type TabName = 'home' | 'history' | 'body' | 'settings'
 
+export interface Settings {
+  defaultSets: number          // 継続達成セット数（ContinuityGauge）
+  trainingDefaultSets: number  // トレーニング記録のデフォルトセット数
+  weightUnit: 'kg' | 'lbs'
+}
+
 export interface CalendarProps {
   currentDate: Date
   onPrevMonth: () => void

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,9 +1,9 @@
-# Strength Log — feat/add-calendar-view
+# Strength Log — feat/add-settings-page
 
 ## Step 1: 計画策定
 
 ### 概要
-トップ画面にカレンダーを設置し、月切り替えと今日の日付ハイライト、ボトムナビゲーションを実装する。
+設定ページを実装する。デフォルトセット数（1〜10）と重量単位（kg/lbs）を設定でき、localStorage で永続化する。
 
 ### 技術設計
 
@@ -11,125 +11,82 @@
 ```
 src/
   types/
-    index.ts                   - 型定義
-  components/
-    Layout/
-      Layout.tsx               - ページラッパー（ボトムナビ含む）
-      Layout.module.css
-    BottomNav/
-      BottomNav.tsx            - ボトムナビゲーション
-      BottomNav.module.css
-    Calendar/
-      Calendar.tsx             - 月カレンダーコンポーネント
-      Calendar.module.css
+    index.ts                         - Settings型を追加
+  hooks/
+    useSettings.ts                   - 新規: localStorage読み書きフック
   pages/
-    HomePage.tsx               - ホーム（カレンダー表示）
-    HistoryPage.tsx            - 履歴（プレースホルダー）
-    BodyPage.tsx               - 体組成（プレースホルダー）
-  App.tsx                      - ルーター設定
-  main.tsx                     - エントリーポイント
-  index.css                    - グローバルスタイル・CSS変数
+    SettingsPage.tsx                 - 本実装（プレースホルダー置き換え）
+    SettingsPage.module.css          - 新規
+  hooks/
+    useSettings.test.ts              - フックのテスト
 ```
 
 #### インターフェース定義
 ```typescript
-// types/index.ts
-export type TabName = 'home' | 'history' | 'body'
-
-export interface CalendarProps {
-  currentDate: Date
-  onPrevMonth: () => void
-  onNextMonth: () => void
-  selectedDate: Date | null
-  onDateSelect: (date: Date) => void
-  markedDates?: string[] // 'YYYY-MM-DD' 形式
+// types/index.ts に追加
+export interface Settings {
+  defaultSets: number      // 1〜10、デフォルト: 3
+  weightUnit: 'kg' | 'lbs' // デフォルト: 'kg'
 }
 
-export interface BottomNavProps {
-  activeTab: TabName
+// hooks/useSettings.ts
+const STORAGE_KEY = 'strength-log-settings'
+export function useSettings(): {
+  settings: Settings
+  updateDefaultSets: (n: number) => void
+  updateWeightUnit: (unit: 'kg' | 'lbs') => void
 }
 ```
 
-#### 依存ライブラリ
-- `date-fns`: 日付計算（新規インストール必要）
-- `react-router-dom`: ルーティング（インストール済み）
-- `vitest` + `@testing-library/react`: テスト（インストール済み）
+#### UI仕様
+- セクション「記録設定」
+  - 「デフォルトセット数」ラベル + `<select>` (1〜10)
+  - 「重量単位」ラベル + トグルボタン (kg / lbs)
+- onChange で即時保存（保存ボタンなし）
+- デザイン: 既存 CSS変数 (--color-primary, --color-bg 等) を使用
 
-#### デザイン仕様
-| 項目 | 値 |
-|---|---|
-| アプリ名 | Strength Log |
-| メインカラー | #22c55e |
-| サブカラー（ホバー） | #16a34a |
-| 背景色 | #f9fafb |
-| テキスト | #111827 |
-| 日曜テキスト | #ef4444（赤） |
-| 土曜テキスト | #3b82f6（青） |
-| 前後月の日付 | #9ca3af（グレー） |
-
-#### カレンダー仕様
-- 今日の日付 → #22c55e 塗りつぶし丸・白テキスト
-- トレーニング記録あり → 日付下に小さい緑ドット
-- 前月・翌月の日付 → グレー表示
-- ヘッダー → 緑背景・白テキスト「Strength Log」
-
-#### ボトムナビ仕様
-| タブ | パス |
-|---|---|
-| ホーム | / |
-| 履歴 | /history |
-| 体組成 | /body |
-
-### Codexセカンドオピニオン結果
-カレンダーUIの自前実装はポートフォリオ観点で妥当。
-date-fnsを用いた月カレンダーは明確な実装方針のためスキップ可と判断。
+### Codexセカンドオピニオン
+設計分岐なし・単純実装のためスキップ可と判断。
 
 ---
 
 ## Step 2: 影響範囲分析
 
 ### 変更対象ファイル
-- `index.html` — タイトル変更・lang="ja"
-- `src/App.tsx` — ルーター設定（全面書き換え）
-- `src/index.css` — グローバルスタイル（全面書き換え）
-- `src/App.css` — 削除（不要）
-- 新規: src/types/index.ts
-- 新規: src/components/Layout/*
-- 新規: src/components/BottomNav/*
-- 新規: src/components/Calendar/*
-- 新規: src/pages/HomePage.tsx
-- 新規: src/pages/HistoryPage.tsx
-- 新規: src/pages/BodyPage.tsx
+- `src/types/index.ts` — Settings型を追加（既存型に影響なし）
+- `src/hooks/useSettings.ts` — 新規
+- `src/pages/SettingsPage.tsx` — プレースホルダー → 本実装
+- `src/pages/SettingsPage.module.css` — 新規
+
+### 非変更ファイル
+- App.tsx（ルーティング済み）
+- Layout.tsx（共通レイアウト）
+- BottomNav.tsx（settings タブ実装済み）
 
 ### リスク評価
-- 既存機能への影響: なし（App.tsxはデフォルトテンプレートのみ）
-- API互換性: なし（新規実装）
-- DB変更: なし
-- 型安全性: strict: true 設定済み、問題なし
+- 既存テスト影響: なし
+- API互換性: なし
+- DB変更: なし（localStorage のみ）
 
 ---
 
 ## 実装チェックリスト
 
-### 事前準備
-- [ ] date-fns インストール
-- [ ] vitest 設定（vite.config.ts）
-- [ ] index.html 更新
-
 ### テスト（Step 3）
-- [ ] Calendar コンポーネントのテスト
-- [ ] BottomNav コンポーネントのテスト
+- [ ] useSettings: 初期値が返る
+- [ ] useSettings: defaultSets更新 → localstorage に保存
+- [ ] useSettings: weightUnit更新 → localStorage に保存
+- [ ] useSettings: localStorage既存値を読み込む
+- [ ] SettingsPage: デフォルトセット数のselectが表示される
+- [ ] SettingsPage: 重量単位トグルが表示される
+- [ ] SettingsPage: select変更でuseSettings.updateDefaultSetsが呼ばれる
+- [ ] SettingsPage: kg/lbsボタンクリックでupdateWeightUnitが呼ばれる
 
 ### 実装（Step 4）
-- [ ] src/index.css — CSS変数・グローバルスタイル
-- [ ] src/types/index.ts — 型定義
-- [ ] src/components/Calendar/Calendar.tsx + .module.css
-- [ ] src/components/BottomNav/BottomNav.tsx + .module.css
-- [ ] src/components/Layout/Layout.tsx + .module.css
-- [ ] src/pages/HomePage.tsx
-- [ ] src/pages/HistoryPage.tsx
-- [ ] src/pages/BodyPage.tsx
-- [ ] src/App.tsx — ルーター設定
+- [ ] src/types/index.ts — Settings型追加
+- [ ] src/hooks/useSettings.ts — フック実装
+- [ ] src/pages/SettingsPage.tsx — UI実装
+- [ ] src/pages/SettingsPage.module.css — スタイル
 
 ### 品質ゲート（Step 5）
 - [ ] npm test 全件PASS


### PR DESCRIPTION
## 実装内容
- `useSettings` フック追加（localStorage で設定を永続化）
- 設定ページ UI：継続達成セット数・デフォルトセット数（各 1〜10）・重量単位（kg / lbs）
- ホーム画面の継続力ゲージに設定値を連携（継続達成セット数）

## テスト内容
- [x] 設定ページで継続達成セット数を変更 → ホームの継続力ゲージヒント文に反映されること
- [x] 設定ページでデフォルトセット数を変更 → 値が保持されること（トレーニング記録機能で使用予定）
- [x] 重量単位 kg / lbs トグルが切り替わり、緑ハイライトされること
- [x] ページ離脱後に戻っても設定値が保持されること（localStorage）
- [x] テスト 35 件すべて PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)