### PR TITLE
feat: 日付詳細ページ実装・カレンダー選択ハイライト修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,14 @@ import HomePage from './pages/HomePage'
 import HistoryPage from './pages/HistoryPage'
 import BodyPage from './pages/BodyPage'
 import SettingsPage from './pages/SettingsPage'
+import DateDetailPage from './pages/DateDetailPage'
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Layout><HomePage /></Layout>} />
+        <Route path="/date/:dateStr" element={<Layout><DateDetailPage /></Layout>} />
         <Route path="/history" element={<Layout><HistoryPage /></Layout>} />
         <Route path="/body" element={<Layout><BodyPage /></Layout>} />
         <Route path="/settings" element={<Layout><SettingsPage /></Layout>} />

--- a/src/components/Calendar/Calendar.module.css
+++ b/src/components/Calendar/Calendar.module.css
@@ -94,6 +94,7 @@
 
 .selected {
   background: #dcfce7;
+  box-shadow: 0 0 0 2px #22c55e;
 }
 
 /* 日曜・祝日 → 赤 */

--- a/src/pages/DateDetailPage.module.css
+++ b/src/pages/DateDetailPage.module.css
@@ -1,0 +1,119 @@
+.page {
+  padding: 0 0 5rem;
+}
+
+/* ── 日付ヘッダー ── */
+.dateBar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.backButton {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.dateTitle {
+  flex: 1;
+  text-align: center;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+/* ── 統計バー ── */
+.statsBar {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-primary);
+}
+
+.statCard {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 0.4rem 0.25rem;
+  text-align: center;
+  color: #fff;
+}
+
+.statLabel {
+  font-size: 0.6rem;
+  font-weight: 500;
+  opacity: 0.9;
+  line-height: 1.3;
+}
+
+.statValue {
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-top: 0.1rem;
+}
+
+/* ── コンテンツエリア ── */
+.content {
+  padding: 1rem;
+}
+
+/* ── 空状態 ── */
+.emptyCard {
+  background: #fff;
+  border-radius: 12px;
+  padding: 3rem 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  text-align: center;
+}
+
+.emptyIcon {
+  font-size: 2.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.emptyText {
+  color: var(--color-gray);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+/* ── FAB ── */
+.fab {
+  position: fixed;
+  bottom: calc(4rem + 1.25rem); /* BottomNav高さ + 余白 */
+  right: 1.25rem;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 3px 8px rgba(34, 197, 94, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fab:hover {
+  background: var(--color-primary-dark);
+}
+
+/* ── エラー ── */
+.errorText {
+  color: var(--color-gray);
+  font-size: 0.95rem;
+  text-align: center;
+  padding: 3rem 0;
+}

--- a/src/pages/DateDetailPage.test.tsx
+++ b/src/pages/DateDetailPage.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import DateDetailPage from './DateDetailPage'
+
+function renderWithRoute(dateStr: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/date/${dateStr}`]}>
+      <Routes>
+        <Route path="/date/:dateStr" element={<DateDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('DateDetailPage', () => {
+  it('有効な dateStr で日本語の日付が表示される', () => {
+    renderWithRoute('2026-04-16')
+    expect(screen.getByText('2026年4月16日（木）')).toBeInTheDocument()
+  })
+
+  it('別の日付でも正しく日本語表示される', () => {
+    renderWithRoute('2026-01-01')
+    expect(screen.getByText('2026年1月1日（木）')).toBeInTheDocument()
+  })
+
+  it('空状態メッセージが表示される', () => {
+    renderWithRoute('2026-04-16')
+    expect(
+      screen.getByText('種目を追加してトレーニングを記録しましょう')
+    ).toBeInTheDocument()
+  })
+
+  it('無効な dateStr でフォールバックテキストが表示される', () => {
+    renderWithRoute('invalid-date')
+    expect(screen.getByText('日付が正しくありません')).toBeInTheDocument()
+  })
+})

--- a/src/pages/DateDetailPage.tsx
+++ b/src/pages/DateDetailPage.tsx
@@ -1,0 +1,89 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import { parseISO, isValid, format } from 'date-fns'
+import styles from './DateDetailPage.module.css'
+
+const WEEKDAYS_JA = ['日', '月', '火', '水', '木', '金', '土']
+
+function formatDateJa(date: Date): string {
+  const weekday = WEEKDAYS_JA[date.getDay()]
+  return `${format(date, 'yyyy年M月d日')}（${weekday}）`
+}
+
+// TODO: 記録機能実装後に実データに置き換える
+const EMPTY_STATS = {
+  exercises: 0,
+  sets: 0,
+  reps: 0,
+  volume: 0,
+}
+
+export default function DateDetailPage() {
+  const { dateStr } = useParams<{ dateStr: string }>()
+  const navigate = useNavigate()
+
+  const date = dateStr ? parseISO(dateStr) : null
+  const isValidDate = date && isValid(date)
+
+  if (!isValidDate) {
+    return (
+      <div className={styles.page}>
+        <p className={styles.errorText}>日付が正しくありません</p>
+      </div>
+    )
+  }
+
+  const stats = EMPTY_STATS
+
+  return (
+    <div className={styles.page}>
+      {/* 日付バー */}
+      <div className={styles.dateBar}>
+        <button
+          className={styles.backButton}
+          onClick={() => navigate('/')}
+          aria-label="戻る"
+        >
+          ＜
+        </button>
+        <span className={styles.dateTitle}>{formatDateJa(date)}</span>
+      </div>
+
+      {/* 統計バー */}
+      <div className={styles.statsBar}>
+        <div className={styles.statCard}>
+          <div className={styles.statLabel}>合計{'\n'}種目数</div>
+          <div className={styles.statValue}>{stats.exercises}</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statLabel}>合計{'\n'}セット数</div>
+          <div className={styles.statValue}>{stats.sets}</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statLabel}>合計{'\n'}レップ数</div>
+          <div className={styles.statValue}>{stats.reps}</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statLabel}>合計{'\n'}負荷量</div>
+          <div className={styles.statValue}>{stats.volume}</div>
+        </div>
+      </div>
+
+      {/* コンテンツ */}
+      <div className={styles.content}>
+        {stats.exercises === 0 && (
+          <div className={styles.emptyCard}>
+            <div className={styles.emptyIcon}>🏋️</div>
+            <p className={styles.emptyText}>
+              種目を追加してトレーニングを記録しましょう
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* FAB（種目追加 - 記録機能実装後に接続） */}
+      <button className={styles.fab} aria-label="種目を追加">
+        ＋
+      </button>
+    </div>
+  )
+}

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import HomePage from './HomePage'
+
+function renderHomePage() {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/date/:dateStr" element={<div data-testid="detail-page" />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('HomePage', () => {
+  it('日付をクリックすると /date/YYYY-MM-DD に遷移する', async () => {
+    renderHomePage()
+    // 今月の "1" の日付セルをクリック
+    const dayCells = screen.getAllByText('1')
+    await userEvent.click(dayCells[0])
+    expect(screen.getByTestId('detail-page')).toBeInTheDocument()
+  })
+})

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { addMonths, subMonths } from 'date-fns'
+import { addMonths, subMonths, format } from 'date-fns'
+import { useNavigate } from 'react-router-dom'
 import Calendar from '../components/Calendar/Calendar'
 import ContinuityGauge from '../components/ContinuityGauge/ContinuityGauge'
 import TrophyBadge from '../components/TrophyBadge/TrophyBadge'
@@ -23,6 +24,7 @@ const STAGE_SAMPLES = [
 
 export default function HomePage() {
   const { settings } = useSettings()
+  const navigate = useNavigate()
   const [currentDate, setCurrentDate] = useState(new Date())
   const [selectedDate, setSelectedDate] = useState<Date | null>(null)
   const [previewGauge, setPreviewGauge] = useState(10)
@@ -30,7 +32,10 @@ export default function HomePage() {
   const handlePrevMonth = () => setCurrentDate((d) => subMonths(d, 1))
   const handleNextMonth = () => setCurrentDate((d) => addMonths(d, 1))
   const handleToday = () => setCurrentDate(new Date())
-  const handleDateSelect = (date: Date) => setSelectedDate(date)
+  const handleDateSelect = (date: Date) => {
+    setSelectedDate(date)
+    navigate(`/date/${format(date, 'yyyy-MM-dd')}`)
+  }
 
   return (
     <div>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,92 +1,74 @@
-# Strength Log — feat/add-settings-page
+# Strength Log — feat/add-date-detail-page
 
 ## Step 1: 計画策定
 
 ### 概要
-設定ページを実装する。デフォルトセット数（1〜10）と重量単位（kg/lbs）を設定でき、localStorage で永続化する。
+カレンダーの日付タップで詳細ページへ遷移する。
+あわせてカレンダーの選択ハイライトを視認しやすく修正する。
 
 ### 技術設計
 
 #### ファイル構成
 ```
 src/
-  types/
-    index.ts                         - Settings型を追加
-  hooks/
-    useSettings.ts                   - 新規: localStorage読み書きフック
   pages/
-    SettingsPage.tsx                 - 本実装（プレースホルダー置き換え）
-    SettingsPage.module.css          - 新規
-  hooks/
-    useSettings.test.ts              - フックのテスト
+    DateDetailPage.tsx           - 新規: 日付詳細ページ
+    DateDetailPage.module.css    - 新規
+  App.tsx                        - /date/:dateStr ルート追加
+  pages/HomePage.tsx             - useNavigate で日付タップ時に遷移
+  components/Calendar/
+    Calendar.module.css          - .selected スタイル修正
 ```
 
 #### インターフェース定義
 ```typescript
-// types/index.ts に追加
-export interface Settings {
-  defaultSets: number      // 1〜10、デフォルト: 3
-  weightUnit: 'kg' | 'lbs' // デフォルト: 'kg'
-}
-
-// hooks/useSettings.ts
-const STORAGE_KEY = 'strength-log-settings'
-export function useSettings(): {
-  settings: Settings
-  updateDefaultSets: (n: number) => void
-  updateWeightUnit: (unit: 'kg' | 'lbs') => void
-}
+// /date/:dateStr  (dateStr: 'YYYY-MM-DD')
+// DateDetailPage: useParams で dateStr を取得し、date-fns で日本語表示
 ```
 
 #### UI仕様
-- セクション「記録設定」
-  - 「デフォルトセット数」ラベル + `<select>` (1〜10)
-  - 「重量単位」ラベル + トグルボタン (kg / lbs)
-- onChange で即時保存（保存ボタンなし）
-- デザイン: 既存 CSS変数 (--color-primary, --color-bg 等) を使用
+- DateDetailPage:
+  - Layout 共通ヘッダー（Strength Log）
+  - 日付タイトル: 「2026年4月16日（木）」
+  - 空状態カード: 「この日のトレーニングはありません」
+  - BottomNav あり（Layout 内）
+- 選択ハイライト:
+  - 現状: background #dcfce7（薄く見づらい）
+  - 修正後: box-shadow で緑リング（今日の塗りつぶしと区別できる）
 
 ### Codexセカンドオピニオン
-設計分岐なし・単純実装のためスキップ可と判断。
+シンプルなナビゲーション追加。スキップ可と判断。
 
 ---
 
 ## Step 2: 影響範囲分析
 
-### 変更対象ファイル
-- `src/types/index.ts` — Settings型を追加（既存型に影響なし）
-- `src/hooks/useSettings.ts` — 新規
-- `src/pages/SettingsPage.tsx` — プレースホルダー → 本実装
-- `src/pages/SettingsPage.module.css` — 新規
-
-### 非変更ファイル
-- App.tsx（ルーティング済み）
-- Layout.tsx（共通レイアウト）
-- BottomNav.tsx（settings タブ実装済み）
+### 変更対象
+- `src/App.tsx` — route追加のみ（既存ルートに影響なし）
+- `src/pages/HomePage.tsx` — useNavigate 追加（onDateSelect の挙動変更）
+- `src/components/Calendar/Calendar.module.css` — .selected スタイルのみ変更
+- 新規: DateDetailPage.tsx / DateDetailPage.module.css
 
 ### リスク評価
-- 既存テスト影響: なし
-- API互換性: なし
-- DB変更: なし（localStorage のみ）
+- 既存テスト影響: Calendar/BottomNav テストは変更なし
+- 型安全性: 問題なし
 
 ---
 
 ## 実装チェックリスト
 
 ### テスト（Step 3）
-- [ ] useSettings: 初期値が返る
-- [ ] useSettings: defaultSets更新 → localstorage に保存
-- [ ] useSettings: weightUnit更新 → localStorage に保存
-- [ ] useSettings: localStorage既存値を読み込む
-- [ ] SettingsPage: デフォルトセット数のselectが表示される
-- [ ] SettingsPage: 重量単位トグルが表示される
-- [ ] SettingsPage: select変更でuseSettings.updateDefaultSetsが呼ばれる
-- [ ] SettingsPage: kg/lbsボタンクリックでupdateWeightUnitが呼ばれる
+- [ ] DateDetailPage: 有効な dateStr で日本語日付が表示される
+- [ ] DateDetailPage: 無効な dateStr でフォールバック表示
+- [ ] DateDetailPage: 空状態メッセージが表示される
+- [ ] HomePage: 日付クリックで /date/YYYY-MM-DD に遷移する
 
 ### 実装（Step 4）
-- [ ] src/types/index.ts — Settings型追加
-- [ ] src/hooks/useSettings.ts — フック実装
-- [ ] src/pages/SettingsPage.tsx — UI実装
-- [ ] src/pages/SettingsPage.module.css — スタイル
+- [ ] src/App.tsx — /date/:dateStr ルート追加
+- [ ] src/pages/HomePage.tsx — useNavigate 導入
+- [ ] src/pages/DateDetailPage.tsx
+- [ ] src/pages/DateDetailPage.module.css
+- [ ] src/components/Calendar/Calendar.module.css — .selected 修正
 
 ### 品質ゲート（Step 5）
 - [ ] npm test 全件PASS


### PR DESCRIPTION
## 実装内容
- 日付タップで `/date/YYYY-MM-DD` へ遷移するナビゲーションを実装
- DateDetailPage: 日付バー・4統計カード（種目数/セット数/レップ数/負荷量）・空状態・FABボタン（参照スクショ準拠）
- Calendar: 選択日に緑リングハイライト追加（視認性改善）

## テスト内容
- [x] カレンダーの日付タップ → 詳細ページに遷移し「YYYY年M月D日（曜）」が表示される
- [x] 詳細ページの「＜」ボタンでホームに戻れる
- [x] 4統計カードとFABボタンが表示される
- [x] 無効な日付URLでエラー表示される
- [x] テスト 40 件すべて PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)