### PR TITLE
fix: 1RMトースト誤表示バグ修正（同セッション内の重複通知を解消）

### DIFF
--- a/src/pages/TrainingEntryPage.tsx
+++ b/src/pages/TrainingEntryPage.tsx
@@ -57,14 +57,14 @@ export default function TrainingEntryPage() {
   const exercise = exercises.find((e) => e.id === exerciseId)
   const date = dateStr ?? ''
 
-  // 過去の歴代最高RM（当日を除く）
-  const historicalBestRM = useMemo(() => {
+  // 全時最高RM（今日のセットを含む。比較はupdateSet前の旧stateで行われるため正確）
+  const bestRM = useMemo(() => {
     if (!exerciseId) return 0
     return records
-      .filter((r) => r.exerciseId === exerciseId && r.date !== date)
+      .filter((r) => r.exerciseId === exerciseId)
       .flatMap((r) => r.sets.map((s) => calcRM(s.weight, s.reps)))
       .reduce((max, rm) => Math.max(max, rm), 0)
-  }, [records, exerciseId, date])
+  }, [records, exerciseId])
 
   // 1RM更新トースト通知
   const [rmToast, setRmToast] = useState<{ rm: number; key: number } | null>(null)
@@ -124,7 +124,7 @@ export default function TrainingEntryPage() {
     const currentSet = record.sets.find((s) => s.id === setId)
     if (currentSet && currentSet.reps > 0) {
       const newRM = calcRM(weightKg, currentSet.reps)
-      if (newRM > historicalBestRM) showRMToast(newRM)
+      if (newRM > bestRM) showRMToast(newRM)
     }
   }
 
@@ -137,7 +137,7 @@ export default function TrainingEntryPage() {
     const currentSet = record.sets.find((s) => s.id === setId)
     if (currentSet && currentSet.weight > 0 && val > 0) {
       const newRM = calcRM(currentSet.weight, val)
-      if (newRM > historicalBestRM) showRMToast(newRM)
+      if (newRM > bestRM) showRMToast(newRM)
     }
   }
 


### PR DESCRIPTION
## 実装内容

- **バグ**: 同一セッション内で最初のセットが RM=182 を達成した後、次のセット（RM=149.3）でも1RM更新トーストが表示されていた
- **原因**: `historicalBestRM` の計算が「当日を除く過去記録のみ」を対象にしていたため、同セッション内の最高RMが比較対象に含まれなかった
- **修正**: `r.date !== date` フィルタを除去し、今日含む全レコードの最高RMと比較するよう変更

## 変更ファイル

- `src/pages/TrainingEntryPage.tsx`
  - `historicalBestRM` → `bestRM` にリネーム
  - フィルタから `&& r.date !== date` を除去
  - useMemo の依存配列から `date` を除去

## 修正の根拠

React の state 更新は非同期なので、`handleRepsChange` / `handleWeightChange` 内で `updateSet` を呼び出した時点では `records` はまだ旧状態。つまり `bestRM` は「現在の入力を反映する前」の全時最高RMを参照しており、比較として正確。

## テスト内容

- [x] `npm test` — 152件全PASS
- [x] `npm run build` — ビルド成功
- [x] インクラインベンチプレスで Set1: 高重量（RM=182）→ Set2: 低重量（RM=149.3）を入力して、Set2 でトーストが出ないことを確認
- [x] 真に歴代最高を更新したセットでのみトーストが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)