### PR TITLE
feat: カレンダー日付タップで部位・種目ポップアップ表示

### DIFF
--- a/src/components/CalendarDayPopup/CalendarDayPopup.module.css
+++ b/src/components/CalendarDayPopup/CalendarDayPopup.module.css
@@ -1,0 +1,127 @@
+/* オーバーレイ */
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* カード */
+.card {
+  background: #fff;
+  border-radius: 20px;
+  width: 300px;
+  max-height: 70vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+  padding: 0;
+  animation: popIn 200ms ease-out;
+}
+
+@keyframes popIn {
+  from {
+    transform: scale(0.92);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* ヘッダー */
+.header {
+  padding: 16px 16px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.dateText {
+  font-size: 16px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #6b7280;
+  padding: 4px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  transition: background 0.15s, color 0.15s;
+}
+
+.closeButton:hover {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+/* ボディ */
+.body {
+  padding: 12px 16px;
+}
+
+/* 部位ラベル */
+.categoryLabel {
+  font-size: 11px;
+  font-weight: 700;
+  color: #1e3a6e;
+  padding: 8px 0 4px;
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+
+.categoryLabelFirst {
+  padding-top: 0;
+}
+
+/* 種目行 */
+.exerciseRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+  border-bottom: 1px solid #f9fafb;
+}
+
+.exerciseName {
+  font-size: 14px;
+  color: #374151;
+}
+
+.setCount {
+  font-size: 13px;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+/* フッター */
+.footer {
+  padding: 12px 16px;
+  border-top: 1px solid #f3f4f6;
+}
+
+.navigateButton {
+  width: 100%;
+  padding: 12px;
+  background: #3b82f6;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.navigateButton:hover {
+  background: #2563eb;
+}

--- a/src/components/CalendarDayPopup/CalendarDayPopup.test.tsx
+++ b/src/components/CalendarDayPopup/CalendarDayPopup.test.tsx
@@ -6,7 +6,7 @@ import type { TrainingRecord, Exercise } from '../../types'
 
 // ── フィクスチャ ──────────────────────────────────────────────────────────────
 
-const DATE = '2026-04-22' // 火曜日
+const DATE = '2026-04-22' // 水曜日
 
 const EXERCISES: Exercise[] = [
   { id: 'ex-chest-1', name: 'ベンチプレス',   categoryId: '胸',  isCustom: false },
@@ -76,7 +76,7 @@ describe('CalendarDayPopup', () => {
   // テスト1: 日付ヘッダー形式
   it('日付が「4月22日（火）」形式で表示される', () => {
     renderPopup()
-    expect(screen.getByText('4月22日（火）')).toBeInTheDocument()
+    expect(screen.getByText('4月22日（水）')).toBeInTheDocument()
   })
 
   // テスト2: 部位ごとのグループ表示
@@ -140,7 +140,7 @@ describe('CalendarDayPopup', () => {
     renderPopup({ onClose })
 
     // 日付ヘッダーをクリック（カード内要素）
-    await user.click(screen.getByText('4月22日（火）'))
+    await user.click(screen.getByText('4月22日（水）'))
     expect(onClose).not.toHaveBeenCalled()
   })
 

--- a/src/components/CalendarDayPopup/CalendarDayPopup.test.tsx
+++ b/src/components/CalendarDayPopup/CalendarDayPopup.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import CalendarDayPopup from './CalendarDayPopup'
+import type { TrainingRecord, Exercise } from '../../types'
+
+// ── フィクスチャ ──────────────────────────────────────────────────────────────
+
+const DATE = '2026-04-22' // 火曜日
+
+const EXERCISES: Exercise[] = [
+  { id: 'ex-chest-1', name: 'ベンチプレス',   categoryId: '胸',  isCustom: false },
+  { id: 'ex-chest-2', name: 'ペックフライ',   categoryId: '胸',  isCustom: false },
+  { id: 'ex-back-1',  name: 'デッドリフト',   categoryId: '背中', isCustom: false },
+]
+
+const RECORDS: TrainingRecord[] = [
+  {
+    id: 'rec-1',
+    date: DATE,
+    exerciseId: 'ex-chest-1',
+    sets: [
+      { id: 's1', weight: 60, reps: 10, memo: '' },
+      { id: 's2', weight: 60, reps: 10, memo: '' },
+      { id: 's3', weight: 60, reps: 10, memo: '' },
+    ],
+  },
+  {
+    id: 'rec-2',
+    date: DATE,
+    exerciseId: 'ex-chest-2',
+    sets: [
+      { id: 's4', weight: 40, reps: 12, memo: '' },
+      { id: 's5', weight: 40, reps: 12, memo: '' },
+    ],
+  },
+  {
+    id: 'rec-3',
+    date: DATE,
+    exerciseId: 'ex-back-1',
+    sets: [
+      { id: 's6', weight: 100, reps: 5, memo: '' },
+    ],
+  },
+]
+
+// ── ヘルパー ──────────────────────────────────────────────────────────────────
+
+function renderPopup(
+  overrides: Partial<{
+    date: string
+    records: TrainingRecord[]
+    exercises: Exercise[]
+    onClose: () => void
+    onNavigate: (date: string) => void
+  }> = {}
+) {
+  const props = {
+    date: DATE,
+    records: RECORDS,
+    exercises: EXERCISES,
+    onClose: vi.fn(),
+    onNavigate: vi.fn(),
+    ...overrides,
+  }
+  return { ...render(<CalendarDayPopup {...props} />), props }
+}
+
+// ── テスト ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('CalendarDayPopup', () => {
+  // テスト1: 日付ヘッダー形式
+  it('日付が「4月22日（火）」形式で表示される', () => {
+    renderPopup()
+    expect(screen.getByText('4月22日（火）')).toBeInTheDocument()
+  })
+
+  // テスト2: 部位ごとのグループ表示
+  it('種目が部位ごとにグループ表示される（カテゴリラベルが表示される）', () => {
+    renderPopup()
+    // 胸・背中 の両カテゴリラベルが表示される
+    expect(screen.getByText('胸')).toBeInTheDocument()
+    expect(screen.getByText('背中')).toBeInTheDocument()
+  })
+
+  // テスト3: 各種目にセット数が表示される
+  it('各種目にセット数（例: 3set）が表示される', () => {
+    renderPopup()
+    // ベンチプレス: 3set
+    expect(screen.getByText('3set')).toBeInTheDocument()
+    // ペックフライ: 2set
+    expect(screen.getByText('2set')).toBeInTheDocument()
+    // デッドリフト: 1set
+    expect(screen.getByText('1set')).toBeInTheDocument()
+  })
+
+  // テスト4: 種目名が表示される
+  it('各種目名が表示される', () => {
+    renderPopup()
+    expect(screen.getByText('ベンチプレス')).toBeInTheDocument()
+    expect(screen.getByText('ペックフライ')).toBeInTheDocument()
+    expect(screen.getByText('デッドリフト')).toBeInTheDocument()
+  })
+
+  // テスト4: X ボタンクリックで onClose が呼ばれる
+  it('Xボタン（aria-label="close" または role="button"）クリックで onClose が呼ばれる', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    renderPopup({ onClose })
+
+    // aria-label="close" のボタン、または "×" / "✕" を探す
+    const closeButton =
+      screen.queryByRole('button', { name: /close/i }) ??
+      screen.queryByLabelText(/close/i) ??
+      screen.getByRole('button', { name: /[×✕xX]/ })
+
+    await user.click(closeButton)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  // テスト5: オーバーレイクリックで onClose が呼ばれる
+  it('オーバーレイ（data-testid="popup-overlay"）クリックで onClose が呼ばれる', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    renderPopup({ onClose })
+
+    const overlay = screen.getByTestId('popup-overlay')
+    await user.click(overlay)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  // テスト6: カードクリックでは onClose が呼ばれない
+  it('カード内クリックでは onClose が呼ばれない', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    renderPopup({ onClose })
+
+    // 日付ヘッダーをクリック（カード内要素）
+    await user.click(screen.getByText('4月22日（火）'))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  // テスト7: 「詳細を見る」ボタンクリックで onNavigate が呼ばれる
+  it('「詳細を見る」ボタンクリックで onNavigate("2026-04-22") が呼ばれる', async () => {
+    const user = userEvent.setup()
+    const onNavigate = vi.fn()
+    renderPopup({ onNavigate })
+
+    const navButton = screen.getByRole('button', { name: '詳細を見る' })
+    await user.click(navButton)
+    expect(onNavigate).toHaveBeenCalledTimes(1)
+    expect(onNavigate).toHaveBeenCalledWith('2026-04-22')
+  })
+
+  // テスト8: レコードが空の場合は空状態メッセージが表示される（防御的テスト）
+  it('records が空の場合は種目リストが表示されない', () => {
+    renderPopup({ records: [] })
+    expect(screen.queryByText('ベンチプレス')).not.toBeInTheDocument()
+    expect(screen.queryByText('胸')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/CalendarDayPopup/CalendarDayPopup.tsx
+++ b/src/components/CalendarDayPopup/CalendarDayPopup.tsx
@@ -1,0 +1,132 @@
+import { getDay, parseISO } from 'date-fns'
+import type { TrainingRecord, Exercise } from '../../types'
+import styles from './CalendarDayPopup.module.css'
+
+interface CalendarDayPopupProps {
+  date: string              // 'YYYY-MM-DD'
+  records: TrainingRecord[] // その日のレコード（全種目）
+  exercises: Exercise[]     // 全種目マスター（name/category取得用）
+  onClose: () => void
+  onNavigate: (date: string) => void
+}
+
+const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'] as const
+
+function formatDate(dateStr: string): string {
+  const date = parseISO(dateStr)
+  const month = date.getMonth() + 1
+  const day = date.getDate()
+  const weekday = WEEKDAYS[getDay(date)]
+  return `${month}月${day}日（${weekday}）`
+}
+
+interface GroupedExercise {
+  categoryId: string
+  items: { name: string; setCount: number }[]
+}
+
+function groupByCategory(
+  records: TrainingRecord[],
+  exercises: Exercise[]
+): GroupedExercise[] {
+  const exerciseMap = new Map(exercises.map((e) => [e.id, e]))
+  const categoryOrder: string[] = []
+  const categoryMap = new Map<string, { name: string; setCount: number }[]>()
+
+  for (const record of records) {
+    const exercise = exerciseMap.get(record.exerciseId)
+    if (!exercise) continue
+
+    const { categoryId, name } = exercise
+
+    if (!categoryMap.has(categoryId)) {
+      categoryMap.set(categoryId, [])
+      categoryOrder.push(categoryId)
+    }
+
+    const items = categoryMap.get(categoryId)!
+    const existing = items.find((item) => item.name === name)
+    if (existing) {
+      existing.setCount += record.sets.length
+    } else {
+      items.push({ name, setCount: record.sets.length })
+    }
+  }
+
+  return categoryOrder.map((categoryId) => ({
+    categoryId,
+    items: categoryMap.get(categoryId)!,
+  }))
+}
+
+export default function CalendarDayPopup({
+  date,
+  records,
+  exercises,
+  onClose,
+  onNavigate,
+}: CalendarDayPopupProps) {
+  const displayDate = formatDate(date)
+  const grouped = groupByCategory(records, exercises)
+
+  return (
+    <div
+      className={styles.overlay}
+      data-testid="popup-overlay"
+      onClick={onClose}
+    >
+      <div
+        className={styles.card}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ヘッダー */}
+        <div className={styles.header}>
+          <span className={styles.dateText}>{displayDate}</span>
+          <button
+            className={styles.closeButton}
+            aria-label="close"
+            onClick={onClose}
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path
+                d="M12 4L4 12M4 4l8 8"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* ボディ */}
+        <div className={styles.body}>
+          {grouped.map((group, groupIndex) => (
+            <div key={group.categoryId}>
+              <div
+                className={`${styles.categoryLabel} ${groupIndex === 0 ? styles.categoryLabelFirst : ''}`}
+              >
+                {group.categoryId}
+              </div>
+              {group.items.map((item) => (
+                <div key={item.name} className={styles.exerciseRow}>
+                  <span className={styles.exerciseName}>{item.name}</span>
+                  <span className={styles.setCount}>{`${item.setCount}set`}</span>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+
+        {/* フッター */}
+        <div className={styles.footer}>
+          <button
+            className={styles.navigateButton}
+            onClick={() => onNavigate(date)}
+          >
+            詳細を見る
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/CalendarDayPopup/CalendarDayPopup.tsx
+++ b/src/components/CalendarDayPopup/CalendarDayPopup.tsx
@@ -44,7 +44,7 @@ function groupByCategory(
       categoryOrder.push(categoryId)
     }
 
-    const items = categoryMap.get(categoryId)!
+    const items = categoryMap.get(categoryId) ?? []
     const existing = items.find((item) => item.name === name)
     if (existing) {
       existing.setCount += record.sets.length
@@ -55,7 +55,7 @@ function groupByCategory(
 
   return categoryOrder.map((categoryId) => ({
     categoryId,
-    items: categoryMap.get(categoryId)!,
+    items: categoryMap.get(categoryId) ?? [],
   }))
 }
 

--- a/src/pages/HistoryPage.test.tsx
+++ b/src/pages/HistoryPage.test.tsx
@@ -102,8 +102,10 @@ describe('HistoryPage - ビュー切り替え', () => {
     expect(screen.queryByText('日')).not.toBeInTheDocument()
   })
 
-  it('「グラフ」ビューで記録がない場合「記録がありません」が表示される', async () => {
+  it('記録がない部位を選択してグラフビューにすると「記録がありません」が表示される', async () => {
     renderHistoryPage()
+    // 腹筋はMOCK_RECORDSに記録がないのでグラフが空になる
+    await userEvent.click(screen.getByRole('button', { name: '腹筋' }))
     await userEvent.click(screen.getByRole('button', { name: 'グラフ' }))
     expect(screen.getByText('記録がありません')).toBeInTheDocument()
   })

--- a/src/pages/HistoryPage.test.tsx
+++ b/src/pages/HistoryPage.test.tsx
@@ -1,13 +1,59 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { PageHeaderProvider } from '../contexts/PageHeaderContext'
 import HistoryPage from './HistoryPage'
+import type { TrainingRecord, Exercise } from '../types'
 
-beforeEach(() => {
-  localStorage.clear()
-})
+// ── フィクスチャ ──────────────────────────────────────────────────────────────
+
+const DATE_WITH_RECORD = '2026-04-22'
+
+const MOCK_EXERCISES: Exercise[] = [
+  { id: 'ex-chest-1', name: 'ベンチプレス', categoryId: '胸', isCustom: false },
+  { id: 'ex-back-1',  name: 'デッドリフト', categoryId: '背中', isCustom: false },
+]
+
+const MOCK_RECORDS: TrainingRecord[] = [
+  {
+    id: 'rec-1',
+    date: DATE_WITH_RECORD,
+    exerciseId: 'ex-chest-1',
+    sets: [
+      { id: 's1', weight: 60, reps: 10, memo: '' },
+      { id: 's2', weight: 60, reps: 10, memo: '' },
+      { id: 's3', weight: 60, reps: 10, memo: '' },
+    ],
+  },
+]
+
+// ── モック ────────────────────────────────────────────────────────────────────
+
+vi.mock('../hooks/useTrainingRecords', () => ({
+  useTrainingRecords: () => ({
+    records: MOCK_RECORDS,
+    getRecordsByDate: (date: string) => MOCK_RECORDS.filter((r) => r.date === date),
+    getRecord: vi.fn(),
+    getLastRecord: vi.fn(),
+    upsertRecord: vi.fn(),
+    addSet: vi.fn(),
+    updateSet: vi.fn(),
+    deleteSet: vi.fn(),
+    removeRecord: vi.fn(),
+  }),
+}))
+
+vi.mock('../hooks/useExercises', () => ({
+  useExercises: () => ({
+    exercises: MOCK_EXERCISES,
+    addExercise: vi.fn(),
+    deleteExercise: vi.fn(),
+    getCategoryExercises: vi.fn(),
+  }),
+}))
+
+// ── ヘルパー ──────────────────────────────────────────────────────────────────
 
 function renderHistoryPage() {
   return render(
@@ -15,17 +61,23 @@ function renderHistoryPage() {
       <MemoryRouter initialEntries={['/history']}>
         <Routes>
           <Route path="/history" element={<HistoryPage />} />
-          <Route path="/date/:dateStr" element={<div data-testid="detail-page" />} />
+          <Route path="/date/:dateStr" element={<div data-testid="date-detail-page" />} />
         </Routes>
       </MemoryRouter>
     </PageHeaderProvider>
   )
 }
 
+// ── テスト ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+})
+
 describe('HistoryPage - タブ表示', () => {
   it('「ALL」タブが表示される', () => {
     renderHistoryPage()
-    // 部位タブのALL
     const allTabs = screen.getAllByText('ALL')
     expect(allTabs.length).toBeGreaterThanOrEqual(1)
   })
@@ -38,7 +90,6 @@ describe('HistoryPage - タブ表示', () => {
 
   it('初期状態でカレンダービューが表示される', () => {
     renderHistoryPage()
-    // カレンダーは曜日ヘッダーを持つ
     expect(screen.getByText('日')).toBeInTheDocument()
     expect(screen.getByText('月')).toBeInTheDocument()
   })
@@ -48,7 +99,6 @@ describe('HistoryPage - ビュー切り替え', () => {
   it('「グラフ」ボタンクリックでグラフビューに切り替わる', async () => {
     renderHistoryPage()
     await userEvent.click(screen.getByRole('button', { name: 'グラフ' }))
-    // カレンダーが消える
     expect(screen.queryByText('日')).not.toBeInTheDocument()
   })
 
@@ -67,7 +117,7 @@ describe('HistoryPage - ビュー切り替え', () => {
 })
 
 describe('HistoryPage - カテゴリタブ', () => {
-  it('デフォルト9部位のタブが表示される', () => {
+  it('デフォルト部位のタブが表示される', () => {
     renderHistoryPage()
     expect(screen.getByText('胸')).toBeInTheDocument()
     expect(screen.getByText('背中')).toBeInTheDocument()
@@ -79,5 +129,32 @@ describe('HistoryPage - カテゴリタブ', () => {
     const chestTab = screen.getByRole('button', { name: '胸' })
     await userEvent.click(chestTab)
     expect(chestTab.className).toContain('tabActive')
+  })
+})
+
+describe('HistoryPage — カレンダー日付クリック × CalendarDayPopup', () => {
+  it('records に記録がある日付をクリックするとポップアップが表示される', async () => {
+    const user = userEvent.setup()
+    renderHistoryPage()
+
+    expect(screen.getByText('カレンダー')).toBeInTheDocument()
+
+    // 22日のセル（記録あり）をクリック
+    const dayCell = screen.getAllByText('22')[0]
+    await user.click(dayCell)
+
+    const overlay = screen.queryByTestId('popup-overlay')
+    expect(overlay).toBeInTheDocument()
+  })
+
+  it('records に記録がない日付をクリックするとポップアップが表示されない', async () => {
+    const user = userEvent.setup()
+    renderHistoryPage()
+
+    // 1日のセル（記録なし）をクリック
+    const dayCells = screen.getAllByText('1')
+    await user.click(dayCells[0])
+
+    expect(screen.queryByTestId('popup-overlay')).not.toBeInTheDocument()
   })
 })

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -12,6 +12,7 @@ import {
   Tooltip,
 } from 'recharts'
 import Calendar from '../components/Calendar/Calendar'
+import CalendarDayPopup from '../components/CalendarDayPopup/CalendarDayPopup'
 import { useTrainingRecords } from '../hooks/useTrainingRecords'
 import { useExercises } from '../hooks/useExercises'
 import { CATEGORIES } from '../data/defaultExercises'
@@ -29,6 +30,7 @@ export default function HistoryPage() {
   const [selectedCategory, setSelectedCategory] = useState<string>(ALL)
   const [selectedExercise, setSelectedExercise] = useState<string>(ALL)
   const [viewMode, setViewMode] = useState<ViewMode>('calendar')
+  const [popupDate, setPopupDate] = useState<string | null>(null)
 
   const { setHeader } = usePageHeader()
   useEffect(() => {
@@ -131,8 +133,14 @@ export default function HistoryPage() {
             onToday={() => setCurrentDate(new Date())}
             selectedDate={selectedDate}
             onDateSelect={(date) => {
-                setSelectedDate(date)
-                navigate(`/date/${format(date, 'yyyy-MM-dd')}`)
+                const dateStr = format(date, 'yyyy-MM-dd')
+                const hasRecords = records.some((r) => r.date === dateStr)
+                if (hasRecords) {
+                  setPopupDate(dateStr)
+                } else {
+                  setSelectedDate(date)
+                  navigate(`/date/${dateStr}`)
+                }
               }}
             achievedDates={stats.trainedDates}
             markIcon={<Dumbbell size={16} strokeWidth={2.5} />}
@@ -154,6 +162,18 @@ export default function HistoryPage() {
             </>
           )}
         </div>
+      )}
+      {popupDate && (
+        <CalendarDayPopup
+          date={popupDate}
+          records={records.filter((r) => r.date === popupDate)}
+          exercises={exercises}
+          onClose={() => setPopupDate(null)}
+          onNavigate={(date) => {
+            setPopupDate(null)
+            navigate(`/date/${date}`)
+          }}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## 実装内容

- HistoryPage のカレンダーで記録がある日付をタップすると、その日の部位・種目・セット数をポップアップで表示
- 「詳細を見る」ボタンから DateDetailPage へ遷移
- 記録がない日付は従来通り DateDetailPage へ直接遷移

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/components/CalendarDayPopup/CalendarDayPopup.tsx` | 新規コンポーネント（オーバーレイ＋カード） |
| `src/components/CalendarDayPopup/CalendarDayPopup.module.css` | スタイル定義 |
| `src/components/CalendarDayPopup/CalendarDayPopup.test.tsx` | コンポーネントテスト 8件 |
| `src/pages/HistoryPage.tsx` | onDateSelect ロジック変更・ポップアップ追加 |
| `src/pages/HistoryPage.test.tsx` | HistoryPage 統合テスト 2件 |

## 機能詳細

- **ポップアップ表示**: 記録あり日をタップ → 種目を部位ごとにグループ表示（部位ラベル＋種目名＋セット数）
- **閉じる操作**: オーバーレイクリック or ✕ボタン
- **遷移**: 「詳細を見る」ボタン → DateDetailPage
- **アニメーション**: scale 0.92→1 + opacity フェードイン（200ms）
- **イベント制御**: カード内クリックは stopPropagation でオーバーレイ閉じをブロック

## テスト内容

- [x] `npm test` — 163件全PASS
- [x] `npm run build` — ビルド成功
- [x] 記録がある日をタップしてポップアップが表示されることを確認
- [x] 部位ごとのグループ表示・種目名・セット数の表示を確認
- [x] ✕ボタン・オーバーレイクリックで閉じることを確認
- [x] 「詳細を見る」で DateDetailPage へ遷移することを確認
- [x] 記録がない日は直接 DateDetailPage へ遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)