### PR TITLE
feat: カスタム種目の筋肉・説明入力対応 + デフォルト種目の情報整備

### DIFF
--- a/src/components/ExerciseDetailModal/ExerciseDetailModal.test.tsx
+++ b/src/components/ExerciseDetailModal/ExerciseDetailModal.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import ExerciseDetailModal from './ExerciseDetailModal'
 import type { WgerStatus, WgerExerciseData } from '../../hooks/useWgerExercise'
+import type { Exercise } from '../../types'
 
 // ---------- useWgerExercise モック ----------
 
@@ -20,9 +21,19 @@ vi.mock('../../hooks/useWgerExercise', () => ({
 
 // ---------- ヘルパー ----------
 
-function renderModal(exerciseName = 'ベンチプレス', onClose = vi.fn()) {
+function makeExercise(overrides: Partial<Exercise> = {}): Exercise {
+  return {
+    id: 'default-0',
+    name: 'ベンチプレス',
+    categoryId: '胸',
+    isCustom: false,
+    ...overrides,
+  }
+}
+
+function renderModal(exerciseOverrides: Partial<Exercise> = {}, onClose = vi.fn()) {
   return render(
-    <ExerciseDetailModal exerciseName={exerciseName} onClose={onClose} />
+    <ExerciseDetailModal exercise={makeExercise(exerciseOverrides)} onClose={onClose} />
   )
 }
 
@@ -53,7 +64,7 @@ describe('ExerciseDetailModal', () => {
       descriptionJa: 'バーベルを使った胸のトレーニング。',
     }
 
-    renderModal('ベンチプレス')
+    renderModal()
 
     expect(screen.getByText('ベンチプレス')).toBeInTheDocument()
   })
@@ -107,21 +118,43 @@ describe('ExerciseDetailModal', () => {
     }
     const onClose = vi.fn()
 
-    renderModal('ベンチプレス', onClose)
+    renderModal({}, onClose)
 
-    // 「閉じる」または × など、role="button" で onClose を発火するボタンを探す
     const closeButton = screen.getByRole('button', { name: /閉じる|×|close/i })
     await userEvent.click(closeButton)
 
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  // ---- 7. マウント時に fetch() が自動で呼ばれる ----
-  it('マウント時に fetch() が自動で呼ばれる', () => {
+  // ---- 7. マウント時に fetch() が自動で呼ばれる（デフォルト種目の場合）----
+  it('デフォルト種目のとき、マウント時に fetch() が自動で呼ばれる', () => {
     mockStatus = 'loading'
 
-    renderModal()
+    renderModal({ isCustom: false })
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  // ---- 8. カスタム種目で muscles が保存されている場合は API を呼ばずに表示 ----
+  it('カスタム種目で muscles が保存されている場合は API を呼ばずに筋肉名が表示される', () => {
+    // mockStatus は idle のまま、fetch は呼ばれないはず
+    renderModal({
+      isCustom: true,
+      muscles: ['大胸筋'],
+      musclesSecondary: ['三角筋前部'],
+      description: 'カスタム種目の説明文。',
+    })
+
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(screen.getByText(/大胸筋/)).toBeInTheDocument()
+    expect(screen.getByText(/三角筋前部/)).toBeInTheDocument()
+    expect(screen.getByText(/カスタム種目の説明文/)).toBeInTheDocument()
+  })
+
+  // ---- 9. カスタム種目でデータがない場合は案内メッセージが表示される ----
+  it('カスタム種目でデータがない場合は「種目追加時に情報を入力すると表示されます」が表示される', () => {
+    renderModal({ isCustom: true })
+
+    expect(screen.getByText(/種目追加時に情報を入力すると表示されます/)).toBeInTheDocument()
   })
 })

--- a/src/components/ExerciseDetailModal/ExerciseDetailModal.tsx
+++ b/src/components/ExerciseDetailModal/ExerciseDetailModal.tsx
@@ -1,59 +1,85 @@
 import { useEffect } from 'react'
 import { useWgerExercise } from '../../hooks/useWgerExercise'
+import type { Exercise } from '../../types'
+import type { WgerExerciseData } from '../../hooks/useWgerExercise'
 import styles from './ExerciseDetailModal.module.css'
 
 interface Props {
-  exerciseName: string
+  exercise: Exercise
   onClose: () => void
 }
 
-export default function ExerciseDetailModal({ exerciseName, onClose }: Props) {
-  const { status, data, fetch } = useWgerExercise(exerciseName)
+export default function ExerciseDetailModal({ exercise, onClose }: Props) {
+  // カスタム種目で保存済みデータがある場合はAPIスキップ
+  const hasCustomData =
+    exercise.isCustom &&
+    ((exercise.muscles?.length ?? 0) > 0 || !!exercise.description)
+
+  const isCustomWithoutData = exercise.isCustom && !hasCustomData
+
+  const { status, data, fetch } = useWgerExercise(
+    hasCustomData || isCustomWithoutData ? '' : exercise.name,
+  )
 
   useEffect(() => {
-    fetch()
-  }, [fetch])
+    if (!hasCustomData && !isCustomWithoutData) fetch()
+  }, [fetch, hasCustomData, isCustomWithoutData])
+
+  const effectiveData: WgerExerciseData | null = hasCustomData
+    ? {
+        muscles: exercise.muscles ?? [],
+        musclesSecondary: exercise.musclesSecondary ?? [],
+        descriptionJa: exercise.description ?? '',
+      }
+    : data
+
+  const effectiveStatus = hasCustomData || isCustomWithoutData ? 'ok' : status
 
   return (
     <div className={styles.overlay} onClick={onClose}>
       <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
-        <h2 className={styles.title}>{exerciseName}</h2>
+        <h2 className={styles.title}>{exercise.name}</h2>
 
-        {status === 'loading' && <p>読み込み中…</p>}
+        {effectiveStatus === 'loading' && <p>読み込み中…</p>}
+        {effectiveStatus === 'error' && <p>詳細情報を取得できませんでした</p>}
 
-        {status === 'error' && <p>詳細情報を取得できませんでした</p>}
-
-        {status === 'ok' && data && (
+        {effectiveStatus === 'ok' && (
           <>
-            <div className={styles.section}>
-              <div className={styles.sectionLabel}>対象筋肉</div>
-              {data.muscles.length > 0 ? (
-                <div className={styles.muscleList}>
-                  {data.muscles.map((m) => (
-                    <span key={m} className={styles.muscleTag}>{m}</span>
-                  ))}
+            {isCustomWithoutData ? (
+              <p className={styles.description}>種目追加時に情報を入力すると表示されます</p>
+            ) : effectiveData && (
+              <>
+                <div className={styles.section}>
+                  <div className={styles.sectionLabel}>対象筋肉</div>
+                  {effectiveData.muscles.length > 0 ? (
+                    <div className={styles.muscleList}>
+                      {effectiveData.muscles.map((m) => (
+                        <span key={m} className={styles.muscleTag}>{m}</span>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className={styles.description}>情報なし</p>
+                  )}
                 </div>
-              ) : (
-                <p className={styles.description}>情報なし</p>
-              )}
-            </div>
 
-            {data.musclesSecondary.length > 0 && (
-              <div className={styles.section}>
-                <div className={styles.sectionLabel}>補助筋</div>
-                <div className={styles.muscleList}>
-                  {data.musclesSecondary.map((m) => (
-                    <span key={m} className={styles.muscleTag}>{m}</span>
-                  ))}
-                </div>
-              </div>
-            )}
+                {effectiveData.musclesSecondary.length > 0 && (
+                  <div className={styles.section}>
+                    <div className={styles.sectionLabel}>補助筋</div>
+                    <div className={styles.muscleList}>
+                      {effectiveData.musclesSecondary.map((m) => (
+                        <span key={m} className={styles.muscleTag}>{m}</span>
+                      ))}
+                    </div>
+                  </div>
+                )}
 
-            {data.descriptionJa && (
-              <div className={styles.section}>
-                <div className={styles.sectionLabel}>説明</div>
-                <p className={styles.description}>{data.descriptionJa}</p>
-              </div>
+                {effectiveData.descriptionJa && (
+                  <div className={styles.section}>
+                    <div className={styles.sectionLabel}>説明</div>
+                    <p className={styles.description}>{effectiveData.descriptionJa}</p>
+                  </div>
+                )}
+              </>
             )}
           </>
         )}

--- a/src/data/defaultExercises.ts
+++ b/src/data/defaultExercises.ts
@@ -52,7 +52,6 @@ const raw: { name: string; categoryId: CategoryId }[] = [
   { name: 'ランニング', categoryId: '有酸素運動' },
   { name: 'ウォーキング', categoryId: '有酸素運動' },
   { name: 'サイクリング', categoryId: '有酸素運動' },
-  { name: 'ロープジャンプ', categoryId: '有酸素運動' },
 ]
 
 export const DEFAULT_EXERCISES: Exercise[] = raw.map((e, i) => ({

--- a/src/data/exerciseMuscleMap.ts
+++ b/src/data/exerciseMuscleMap.ts
@@ -1,6 +1,7 @@
 interface MuscleData {
   muscles: string[]
   musclesSecondary: string[]
+  description?: string
 }
 
 export const EXERCISE_MUSCLE_MAP: Record<string, MuscleData> = {
@@ -43,4 +44,31 @@ export const EXERCISE_MUSCLE_MAP: Record<string, MuscleData> = {
   'クランチ':                          { muscles: ['腹直筋'],              musclesSecondary: [] },
   'プランク':                          { muscles: ['腹横筋'],              musclesSecondary: ['腹直筋', '脊柱起立筋'] },
   'サイドプランク':                    { muscles: ['腹斜筋'],              musclesSecondary: ['腹横筋'] },
+  // 追加種目
+  'ペックフライ':                      { muscles: ['大胸筋'],                       musclesSecondary: ['三角筋前部'] },
+  'プーリーロー':                      { muscles: ['広背筋', '菱形筋'],             musclesSecondary: ['上腕二頭筋', '僧帽筋'] },
+  'ベントオーバーロウ':                { muscles: ['広背筋', '僧帽筋', '菱形筋'],   musclesSecondary: ['上腕二頭筋', '脊柱起立筋'] },
+  'トライセップスエクステンション':    { muscles: ['上腕三頭筋'],                   musclesSecondary: [] },
+  'プリーチャーカール':                { muscles: ['上腕二頭筋'],                   musclesSecondary: ['上腕筋'] },
+  'トライセップスプレスダウン':        { muscles: ['上腕三頭筋'],                   musclesSecondary: [] },
+  'グルートブリッジ':                  { muscles: ['大臀筋'],                       musclesSecondary: ['ハムストリングス'] },
+  'ブルガリアンスクワット':            { muscles: ['大腿四頭筋', '大臀筋'],         musclesSecondary: ['ハムストリングス'] },
+  'レッグレイズ':                      { muscles: ['腹直筋（下部）'],               musclesSecondary: ['腸腰筋'] },
+  'ロシアンツイスト':                  { muscles: ['腹斜筋'],                       musclesSecondary: ['腹直筋'] },
+  // 有酸素運動（静的説明あり）
+  'ランニング': {
+    muscles: [],
+    musclesSecondary: [],
+    description: 'ランニングは全身持久力を高める代表的な有酸素運動。心肺機能の強化とカロリー消費に優れ、継続することで体脂肪の燃焼効果が高まる。ペースや距離を変えることで運動強度を自由にコントロールできる。',
+  },
+  'ウォーキング': {
+    muscles: [],
+    musclesSecondary: [],
+    description: 'ウォーキングは低強度の有酸素運動で、関節への負担が少なく幅広い年齢層・体力レベルに適している。継続的に行うことで心肺機能の向上・基礎代謝の改善・体脂肪の緩やかな減少が期待できる。',
+  },
+  'サイクリング': {
+    muscles: ['大腿四頭筋', 'ハムストリングス', '腓腹筋'],
+    musclesSecondary: ['大臀筋'],
+    description: 'サイクリングは下半身の筋肉を中心に使う有酸素運動。膝関節への負担が少なく、脚の筋持久力と心肺機能を同時に鍛えられる。強度の調整が容易で、ゆったりとした移動からハードなトレーニングまで幅広く対応できる。',
+  },
 }

--- a/src/hooks/useExercises.ts
+++ b/src/hooks/useExercises.ts
@@ -23,12 +23,21 @@ function save(exercises: Exercise[]): void {
 export function useExercises() {
   const [exercises, setExercises] = useState<Exercise[]>(loadExercises)
 
-  function addExercise(params: { name: string; categoryId: CategoryId }) {
+  function addExercise(params: {
+    name: string
+    categoryId: CategoryId
+    muscles?: string[]
+    musclesSecondary?: string[]
+    description?: string
+  }) {
     const newExercise: Exercise = {
       id: `custom-${Date.now()}`,
       name: params.name,
       categoryId: params.categoryId,
       isCustom: true,
+      ...(params.muscles !== undefined && { muscles: params.muscles }),
+      ...(params.musclesSecondary !== undefined && { musclesSecondary: params.musclesSecondary }),
+      ...(params.description !== undefined && { description: params.description }),
     }
     setExercises((prev) => {
       const next = [...prev, newExercise]

--- a/src/hooks/useWgerExercise.test.ts
+++ b/src/hooks/useWgerExercise.test.ts
@@ -107,4 +107,14 @@ describe('useWgerExercise', () => {
     expect(result.current.status).toBe('idle')
     expect(fetchMock).not.toHaveBeenCalled()
   })
+
+  it('静的 description がある種目（ランニング）は Wikipedia API を呼ばずに status="ok" になる', async () => {
+    const { result } = renderHook(() => useWgerExercise('ランニング'))
+    act(() => { result.current.fetch() })
+    await waitFor(() => expect(result.current.status).toBe('ok'))
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.data!.descriptionJa).toContain('有酸素運動')
+    expect(result.current.data!.muscles).toEqual([])
+  })
 })

--- a/src/hooks/useWgerExercise.ts
+++ b/src/hooks/useWgerExercise.ts
@@ -25,7 +25,8 @@ async function fetchDescription(jaName: string): Promise<string> {
 
 async function loadExerciseData(jaName: string): Promise<WgerExerciseData> {
   const muscleData = EXERCISE_MUSCLE_MAP[jaName] ?? { muscles: [], musclesSecondary: [] }
-  const descriptionJa = await fetchDescription(jaName)
+  // 静的説明文がある場合は Wikipedia フェッチをスキップ
+  const descriptionJa = muscleData.description ?? await fetchDescription(jaName)
   return {
     muscles: muscleData.muscles,
     musclesSecondary: muscleData.musclesSecondary,

--- a/src/pages/ExerciseAddPage.test.tsx
+++ b/src/pages/ExerciseAddPage.test.tsx
@@ -69,10 +69,12 @@ describe('ExerciseAddPage', () => {
     await userEvent.type(inputs[0], '胸')
     await userEvent.type(inputs[1], 'テスト種目')
     await userEvent.click(screen.getByText('登録'))
-    expect(mockAddExercise).toHaveBeenCalledWith({
-      name: 'テスト種目',
-      categoryId: '胸',
-    })
+    expect(mockAddExercise).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'テスト種目',
+        categoryId: '胸',
+      })
+    )
   })
 
   it('登録後に選択画面に戻る', async () => {

--- a/src/pages/ExerciseAddPage.tsx
+++ b/src/pages/ExerciseAddPage.tsx
@@ -11,12 +11,23 @@ export default function ExerciseAddPage() {
 
   const [categoryId, setCategoryId] = useState('')
   const [name, setName] = useState('')
+  const [musclesInput, setMusclesInput] = useState('')
+  const [musclesSecondaryInput, setMusclesSecondaryInput] = useState('')
+  const [descriptionInput, setDescriptionInput] = useState('')
 
   const canRegister = name.trim().length > 0 && categoryId.trim().length > 0
 
   function handleRegister() {
     if (!canRegister) return
-    addExercise({ name: name.trim(), categoryId: categoryId.trim() })
+    addExercise({
+      name: name.trim(),
+      categoryId: categoryId.trim(),
+      muscles: musclesInput ? musclesInput.split(',').map((s) => s.trim()).filter(Boolean) : undefined,
+      musclesSecondary: musclesSecondaryInput
+        ? musclesSecondaryInput.split(',').map((s) => s.trim()).filter(Boolean)
+        : undefined,
+      description: descriptionInput.trim() || undefined,
+    })
     navigate(`/date/${dateStr}/exercises/select`)
   }
 
@@ -61,6 +72,36 @@ export default function ExerciseAddPage() {
             placeholder="種目名を入力"
             value={name}
             onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div className={styles.row}>
+          <span className={styles.label}>対象筋肉</span>
+          <input
+            className={styles.input}
+            type="text"
+            placeholder="例: 大胸筋, 上腕三頭筋"
+            value={musclesInput}
+            onChange={(e) => setMusclesInput(e.target.value)}
+          />
+        </div>
+        <div className={styles.row}>
+          <span className={styles.label}>補助筋</span>
+          <input
+            className={styles.input}
+            type="text"
+            placeholder="例: 三角筋前部"
+            value={musclesSecondaryInput}
+            onChange={(e) => setMusclesSecondaryInput(e.target.value)}
+          />
+        </div>
+        <div className={styles.row}>
+          <span className={styles.label}>説明</span>
+          <textarea
+            className={styles.input}
+            placeholder="種目の説明を入力（任意）"
+            value={descriptionInput}
+            onChange={(e) => setDescriptionInput(e.target.value)}
+            rows={3}
           />
         </div>
       </div>

--- a/src/pages/ExerciseSelectPage.tsx
+++ b/src/pages/ExerciseSelectPage.tsx
@@ -4,6 +4,7 @@ import { useExercises } from '../hooks/useExercises'
 import { usePageHeader } from '../contexts/PageHeaderContext'
 import { CATEGORIES } from '../data/defaultExercises'
 import ExerciseDetailModal from '../components/ExerciseDetailModal/ExerciseDetailModal'
+import type { Exercise } from '../types'
 import styles from './ExerciseSelectPage.module.css'
 
 const INITIAL_SHOW = 3
@@ -16,7 +17,7 @@ export default function ExerciseSelectPage() {
 
   const [isEditMode, setIsEditMode] = useState(false)
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set())
-  const [detailExerciseName, setDetailExerciseName] = useState<string | null>(null)
+  const [detailExercise, setDetailExercise] = useState<Exercise | null>(null)
 
   useEffect(() => {
     setHeader({ title: '種目を選択', centered: true })
@@ -99,7 +100,7 @@ export default function ExerciseSelectPage() {
                           aria-label="詳細を見る"
                           onClick={(e) => {
                             e.stopPropagation()
-                            setDetailExerciseName(ex.name)
+                            setDetailExercise(ex)
                           }}
                         >
                           ℹ
@@ -134,10 +135,10 @@ export default function ExerciseSelectPage() {
         戻る
       </button>
 
-      {detailExerciseName && (
+      {detailExercise && (
         <ExerciseDetailModal
-          exerciseName={detailExerciseName}
-          onClose={() => setDetailExerciseName(null)}
+          exercise={detailExercise}
+          onClose={() => setDetailExercise(null)}
         />
       )}
     </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,9 @@ export interface Exercise {
   name: string
   categoryId: CategoryId
   isCustom: boolean
+  muscles?: string[]
+  musclesSecondary?: string[]
+  description?: string
 }
 
 export interface BodyRecord {


### PR DESCRIPTION
## Summary
- カスタム種目追加時に対象筋肉・補助筋・説明をテキスト入力できるよう機能追加
- ExerciseDetailModalでカスタム種目は入力済みデータを直接表示（API呼び出しなし）
- デフォルト種目のexerciseMuscleMapに全件の筋肉データを追加
- ランニング・ウォーキング・サイクリングにデフォルト説明文を内蔵
- ロープジャンプを削除（Wikipedia情報なし・有酸素種目として有用性低）
- Exercise型にオプションフィールド（muscles?, musclesSecondary?, description?）を追加

## Test plan
- [ ] カスタム種目追加画面で筋肉・説明フィールドが表示されることを確認
- [ ] 筋肉・説明を入力して種目を保存し、ℹボタンで正しく表示されることを確認
- [ ] 情報なしのカスタム種目は「カスタム種目のため詳細情報はありません」と表示されることを確認
- [ ] ランニング・ウォーキング・サイクリングの説明がモーダルに表示されることを確認
- [ ] デフォルト種目（ベンチプレス等）の筋肉タグが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)