### PR TITLE
docs: Wikipedia API・カスタム種目機能のコードにコメントを追加

### DIFF
--- a/src/components/ExerciseDetailModal/ExerciseDetailModal.tsx
+++ b/src/components/ExerciseDetailModal/ExerciseDetailModal.tsx
@@ -10,21 +10,25 @@ interface Props {
 }
 
 export default function ExerciseDetailModal({ exercise, onClose }: Props) {
-  // カスタム種目で保存済みデータがある場合はAPIスキップ
+  // カスタム種目かつ筋肉または説明が保存されている場合 → APIスキップしてローカルデータを表示
   const hasCustomData =
     exercise.isCustom &&
     ((exercise.muscles?.length ?? 0) > 0 || !!exercise.description)
 
+  // カスタム種目だが追加時に情報を入力しなかった場合 → 「入力すると表示されます」と案内
   const isCustomWithoutData = exercise.isCustom && !hasCustomData
 
+  // jaName を空文字にすることで useWgerExercise 内のフェッチをスキップさせる
   const { status, data, fetch } = useWgerExercise(
     hasCustomData || isCustomWithoutData ? '' : exercise.name,
   )
 
   useEffect(() => {
+    // デフォルト種目のみAPIを呼び出す（カスタム種目はスキップ）
     if (!hasCustomData && !isCustomWithoutData) fetch()
   }, [fetch, hasCustomData, isCustomWithoutData])
 
+  // カスタム種目の保存データをAPI応答と同じ形に揃える（表示ロジックを統一するため）
   const effectiveData: WgerExerciseData | null = hasCustomData
     ? {
         muscles: exercise.muscles ?? [],
@@ -33,6 +37,7 @@ export default function ExerciseDetailModal({ exercise, onClose }: Props) {
       }
     : data
 
+  // カスタム種目はAPI待ち不要なので常に 'ok' として扱い、ローディング表示を出さない
   const effectiveStatus = hasCustomData || isCustomWithoutData ? 'ok' : status
 
   return (
@@ -46,6 +51,7 @@ export default function ExerciseDetailModal({ exercise, onClose }: Props) {
         {effectiveStatus === 'ok' && (
           <>
             {isCustomWithoutData ? (
+              // 情報なしのカスタム種目：次回の入力を促すガイドメッセージ
               <p className={styles.description}>種目追加時に情報を入力すると表示されます</p>
             ) : effectiveData && (
               <>
@@ -73,6 +79,7 @@ export default function ExerciseDetailModal({ exercise, onClose }: Props) {
                   </div>
                 )}
 
+                {/* Wikipedia説明文が空（記事なし）の場合はセクション自体を非表示 */}
                 {effectiveData.descriptionJa && (
                   <div className={styles.section}>
                     <div className={styles.sectionLabel}>説明</div>

--- a/src/data/exerciseMuscleMap.ts
+++ b/src/data/exerciseMuscleMap.ts
@@ -1,10 +1,15 @@
+// デフォルト種目の筋肉情報を静的に管理するマップ
+// wger REST APIが廃止されたため静的データで代替。正確性を担保しつつAPIリクエストを削減できる。
+// description を持つ種目は Wikipedia API を呼ばずにこの文字列を直接表示する
+
 interface MuscleData {
-  muscles: string[]
-  musclesSecondary: string[]
-  description?: string
+  muscles: string[]          // 対象筋肉（主動筋）
+  musclesSecondary: string[] // 補助筋（協働筋）
+  description?: string       // 静的説明文（省略時は Wikipedia API で取得）
 }
 
 export const EXERCISE_MUSCLE_MAP: Record<string, MuscleData> = {
+  // ── 胸 ──────────────────────────────────────────────────────────────
   'ベンチプレス':                      { muscles: ['大胸筋'],              musclesSecondary: ['上腕三頭筋', '三角筋前部'] },
   'インクラインベンチプレス':          { muscles: ['大胸筋（上部）'],       musclesSecondary: ['上腕三頭筋', '三角筋前部'] },
   'デクラインベンチプレス':            { muscles: ['大胸筋（下部）'],       musclesSecondary: ['上腕三頭筋', '三角筋前部'] },
@@ -13,6 +18,8 @@ export const EXERCISE_MUSCLE_MAP: Record<string, MuscleData> = {
   'プッシュアップ':                    { muscles: ['大胸筋'],              musclesSecondary: ['上腕三頭筋', '三角筋前部'] },
   'ディップス':                        { muscles: ['大胸筋', '上腕三頭筋'], musclesSecondary: ['三角筋前部'] },
   'チェストプレス':                    { muscles: ['大胸筋'],              musclesSecondary: ['上腕三頭筋', '三角筋前部'] },
+  'ペックフライ':                      { muscles: ['大胸筋'],              musclesSecondary: ['三角筋前部'] },
+  // ── 背中 ─────────────────────────────────────────────────────────────
   'デッドリフト':                      { muscles: ['脊柱起立筋', '大臀筋', 'ハムストリングス'], musclesSecondary: ['僧帽筋', '広背筋'] },
   '懸垂':                              { muscles: ['広背筋'],              musclesSecondary: ['上腕二頭筋', '僧帽筋'] },
   'チンアップ':                        { muscles: ['広背筋'],              musclesSecondary: ['上腕二頭筋'] },
@@ -21,6 +28,9 @@ export const EXERCISE_MUSCLE_MAP: Record<string, MuscleData> = {
   'バーベルロウ':                      { muscles: ['広背筋', '僧帽筋'],     musclesSecondary: ['上腕二頭筋', '脊柱起立筋'] },
   'ダンベルロウ':                      { muscles: ['広背筋', '菱形筋'],     musclesSecondary: ['上腕二頭筋'] },
   'フェイスプル':                      { muscles: ['三角筋後部', '菱形筋'], musclesSecondary: ['僧帽筋'] },
+  'プーリーロー':                      { muscles: ['広背筋', '菱形筋'],     musclesSecondary: ['上腕二頭筋', '僧帽筋'] },
+  'ベントオーバーロウ':                { muscles: ['広背筋', '僧帽筋', '菱形筋'], musclesSecondary: ['上腕二頭筋', '脊柱起立筋'] },
+  // ── 脚 ──────────────────────────────────────────────────────────────
   'スクワット':                        { muscles: ['大腿四頭筋', '大臀筋'], musclesSecondary: ['ハムストリングス', '脊柱起立筋'] },
   'レッグプレス':                      { muscles: ['大腿四頭筋', '大臀筋'], musclesSecondary: ['ハムストリングス'] },
   'ランジ':                            { muscles: ['大腿四頭筋', '大臀筋'], musclesSecondary: ['ハムストリングス'] },
@@ -28,34 +38,34 @@ export const EXERCISE_MUSCLE_MAP: Record<string, MuscleData> = {
   'レッグカール':                      { muscles: ['ハムストリングス'],     musclesSecondary: [] },
   'レッグエクステンション':            { muscles: ['大腿四頭筋'],           musclesSecondary: [] },
   'カーフレイズ':                      { muscles: ['腓腹筋'],              musclesSecondary: ['ヒラメ筋'] },
+  'ブルガリアンスクワット':            { muscles: ['大腿四頭筋', '大臀筋'], musclesSecondary: ['ハムストリングス'] },
+  // ── 肩 ──────────────────────────────────────────────────────────────
   'ショルダープレス':                  { muscles: ['三角筋'],              musclesSecondary: ['上腕三頭筋', '僧帽筋'] },
   'アーノルドプレス':                  { muscles: ['三角筋'],              musclesSecondary: ['上腕三頭筋'] },
   'サイドレイズ':                      { muscles: ['三角筋（側部）'],       musclesSecondary: ['僧帽筋'] },
   'フロントレイズ':                    { muscles: ['三角筋（前部）'],       musclesSecondary: [] },
   'リアデルトフライ':                  { muscles: ['三角筋（後部）'],       musclesSecondary: ['菱形筋'] },
+  // ── 腕 ──────────────────────────────────────────────────────────────
   'バーベルカール':                    { muscles: ['上腕二頭筋'],           musclesSecondary: ['上腕筋', '腕橈骨筋'] },
   'ダンベルカール':                    { muscles: ['上腕二頭筋'],           musclesSecondary: ['上腕筋'] },
   'ハンマーカール':                    { muscles: ['上腕筋', '腕橈骨筋'],   musclesSecondary: ['上腕二頭筋'] },
   'トライセプスプッシュダウン':        { muscles: ['上腕三頭筋'],           musclesSecondary: [] },
   'スカルクラッシャー':                { muscles: ['上腕三頭筋'],           musclesSecondary: [] },
   'オーバーヘッドトライセプスエクステンション': { muscles: ['上腕三頭筋'], musclesSecondary: [] },
+  'プリーチャーカール':                { muscles: ['上腕二頭筋'],           musclesSecondary: ['上腕筋'] },
+  'トライセップスエクステンション':    { muscles: ['上腕三頭筋'],           musclesSecondary: [] },
+  'トライセップスプレスダウン':        { muscles: ['上腕三頭筋'],           musclesSecondary: [] },
+  // ── お尻 ─────────────────────────────────────────────────────────────
   'ヒップスラスト':                    { muscles: ['大臀筋'],              musclesSecondary: ['ハムストリングス'] },
   'グルートキックバック':              { muscles: ['大臀筋'],              musclesSecondary: [] },
+  'グルートブリッジ':                  { muscles: ['大臀筋'],              musclesSecondary: ['ハムストリングス'] },
+  // ── 腹筋 ─────────────────────────────────────────────────────────────
   'クランチ':                          { muscles: ['腹直筋'],              musclesSecondary: [] },
   'プランク':                          { muscles: ['腹横筋'],              musclesSecondary: ['腹直筋', '脊柱起立筋'] },
   'サイドプランク':                    { muscles: ['腹斜筋'],              musclesSecondary: ['腹横筋'] },
-  // 追加種目
-  'ペックフライ':                      { muscles: ['大胸筋'],                       musclesSecondary: ['三角筋前部'] },
-  'プーリーロー':                      { muscles: ['広背筋', '菱形筋'],             musclesSecondary: ['上腕二頭筋', '僧帽筋'] },
-  'ベントオーバーロウ':                { muscles: ['広背筋', '僧帽筋', '菱形筋'],   musclesSecondary: ['上腕二頭筋', '脊柱起立筋'] },
-  'トライセップスエクステンション':    { muscles: ['上腕三頭筋'],                   musclesSecondary: [] },
-  'プリーチャーカール':                { muscles: ['上腕二頭筋'],                   musclesSecondary: ['上腕筋'] },
-  'トライセップスプレスダウン':        { muscles: ['上腕三頭筋'],                   musclesSecondary: [] },
-  'グルートブリッジ':                  { muscles: ['大臀筋'],                       musclesSecondary: ['ハムストリングス'] },
-  'ブルガリアンスクワット':            { muscles: ['大腿四頭筋', '大臀筋'],         musclesSecondary: ['ハムストリングス'] },
-  'レッグレイズ':                      { muscles: ['腹直筋（下部）'],               musclesSecondary: ['腸腰筋'] },
-  'ロシアンツイスト':                  { muscles: ['腹斜筋'],                       musclesSecondary: ['腹直筋'] },
-  // 有酸素運動（静的説明あり）
+  'レッグレイズ':                      { muscles: ['腹直筋（下部）'],       musclesSecondary: ['腸腰筋'] },
+  'ロシアンツイスト':                  { muscles: ['腹斜筋'],              musclesSecondary: ['腹直筋'] },
+  // ── 有酸素運動（Wikipedia記事が少ないため説明文を静的に内蔵）────────────
   'ランニング': {
     muscles: [],
     musclesSecondary: [],

--- a/src/hooks/useExercises.ts
+++ b/src/hooks/useExercises.ts
@@ -35,6 +35,7 @@ export function useExercises() {
       name: params.name,
       categoryId: params.categoryId,
       isCustom: true,
+      // undefined のフィールドはオブジェクトに含めない（localStorage の肥大化を防ぐ）
       ...(params.muscles !== undefined && { muscles: params.muscles }),
       ...(params.musclesSecondary !== undefined && { musclesSecondary: params.musclesSecondary }),
       ...(params.description !== undefined && { description: params.description }),

--- a/src/hooks/useWgerExercise.ts
+++ b/src/hooks/useWgerExercise.ts
@@ -3,26 +3,33 @@ import { EXERCISE_MUSCLE_MAP } from '../data/exerciseMuscleMap'
 
 export type WgerStatus = 'idle' | 'loading' | 'ok' | 'error'
 
+// 種目詳細モーダルに表示するデータ型
 export interface WgerExerciseData {
-  muscles: string[]
-  musclesSecondary: string[]
-  descriptionJa: string
+  muscles: string[]          // 対象筋肉
+  musclesSecondary: string[] // 補助筋
+  descriptionJa: string      // 日本語説明文
 }
 
+// セッション内でAPIレスポンスを再利用するためのメモリキャッシュ（種目名 → データ）
 const cache = new Map<string, WgerExerciseData>()
 
+// テスト間でキャッシュ汚染を防ぐためにexport（beforeEachで呼び出す）
 export function clearCache(): void {
   cache.clear()
 }
 
+// 日本語Wikipedia REST APIから種目の説明文を取得する
+// 無料・認証不要・日本語テキストを直接返すため翻訳処理が不要
 async function fetchDescription(jaName: string): Promise<string> {
   const encoded = encodeURIComponent(jaName)
   const res = await fetch(`https://ja.wikipedia.org/api/rest_v1/page/summary/${encoded}`)
-  if (!res.ok) return ''
+  if (!res.ok) return '' // 記事が存在しない場合は空文字を返す（非表示にする）
   const json = await res.json() as { extract?: string }
   return json.extract ?? ''
 }
 
+// 筋肉情報（静的）＋説明文（静的 or Wikipedia）を組み合わせてデータを構築する
+// description が静的マップにある場合はAPIを呼ばずにスキップする
 async function loadExerciseData(jaName: string): Promise<WgerExerciseData> {
   const muscleData = EXERCISE_MUSCLE_MAP[jaName] ?? { muscles: [], musclesSecondary: [] }
   // 静的説明文がある場合は Wikipedia フェッチをスキップ
@@ -43,8 +50,10 @@ export function useWgerExercise(jaName: string): {
   const [data, setData] = useState<WgerExerciseData | null>(null)
 
   const fetchData = useCallback(() => {
+    // 空文字の場合はカスタム種目（API不要）または呼び出し不要なケース
     if (!jaName) return
 
+    // 同一種目の2回目以降はキャッシュから返してAPIを叩かない
     const cached = cache.get(jaName)
     if (cached) {
       setData(cached)

--- a/src/pages/ExerciseAddPage.tsx
+++ b/src/pages/ExerciseAddPage.tsx
@@ -11,10 +11,12 @@ export default function ExerciseAddPage() {
 
   const [categoryId, setCategoryId] = useState('')
   const [name, setName] = useState('')
+  // 筋肉はカンマ区切り入力（例: "大胸筋, 上腕三頭筋"）→ 保存時に配列へ変換
   const [musclesInput, setMusclesInput] = useState('')
   const [musclesSecondaryInput, setMusclesSecondaryInput] = useState('')
   const [descriptionInput, setDescriptionInput] = useState('')
 
+  // 部位と種目名が入力されている場合のみ登録ボタンを有効化
   const canRegister = name.trim().length > 0 && categoryId.trim().length > 0
 
   function handleRegister() {
@@ -22,6 +24,7 @@ export default function ExerciseAddPage() {
     addExercise({
       name: name.trim(),
       categoryId: categoryId.trim(),
+      // 入力がある場合のみフィールドを含める（空文字入力は「情報なし」扱いにしない）
       muscles: musclesInput ? musclesInput.split(',').map((s) => s.trim()).filter(Boolean) : undefined,
       musclesSecondary: musclesSecondaryInput
         ? musclesSecondaryInput.split(',').map((s) => s.trim()).filter(Boolean)
@@ -52,7 +55,7 @@ export default function ExerciseAddPage() {
         </button>
       </div>
 
-      {/* フォーム */}
+      {/* フォーム：部位・種目名は必須、筋肉・補助筋・説明は任意 */}
       <div className={styles.form}>
         <div className={styles.row}>
           <span className={styles.label}>部位</span>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,9 +30,10 @@ export interface Exercise {
   name: string
   categoryId: CategoryId
   isCustom: boolean
-  muscles?: string[]
-  musclesSecondary?: string[]
-  description?: string
+  // 以下3フィールドはカスタム種目追加時に任意入力。デフォルト種目は exerciseMuscleMap.ts で管理
+  muscles?: string[]          // 対象筋肉（主動筋）
+  musclesSecondary?: string[] // 補助筋（協働筋）
+  description?: string        // 種目の説明文
 }
 
 export interface BodyRecord {


### PR DESCRIPTION
## Summary
- PR #8（Wikipedia API切り替え）・PR #9（カスタム種目入力）で追加したコードに日本語コメントを挿入
- ポートフォリオのFiles Changedタブで追加コードの意図・理由が読み取れるようにする

## 対象ファイル
- `useWgerExercise.ts` — キャッシュの目的・Wikipedia API選定理由・フェッチスキップ条件
- `exerciseMuscleMap.ts` — 静的データ化の背景・カテゴリ別整理・description内蔵の理由
- `ExerciseDetailModal.tsx` — カスタム/デフォルト種目の表示分岐ロジック
- `ExerciseAddPage.tsx` — カンマ区切り入力の変換処理・必須/任意フィールドの区別
- `types/index.ts` — Exercise型の任意フィールド（muscles/description）の用途
- `useExercises.ts` — undefinedフィールドを除外するスプレッド演算子の意図

🤖 Generated with [Claude Code](https://claude.com/claude-code)