### PR TITLE
feat: 設定画面に「全データをリセット」ボタンを追加

### DIFF
--- a/src/pages/SettingsPage.module.css
+++ b/src/pages/SettingsPage.module.css
@@ -81,3 +81,25 @@
   background: var(--color-primary);
   color: #fff;
 }
+
+.dangerSection {
+  margin-top: 1rem;
+}
+
+.resetButton {
+  padding: 0.4rem 1rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+  font-weight: 600;
+  background: #fff;
+  border: 1.5px solid #ef4444;
+  border-radius: 8px;
+  color: #ef4444;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.resetButton:hover {
+  background: #ef4444;
+  color: #fff;
+}

--- a/src/pages/SettingsPage.module.css
+++ b/src/pages/SettingsPage.module.css
@@ -82,23 +82,26 @@
   color: #fff;
 }
 
+/* データ管理セクションを記録設定セクションから間隔を空けて配置 */
 .dangerSection {
   margin-top: 1rem;
 }
 
+/* 破壊的操作であることを赤いアウトラインで示すリセットボタン */
 .resetButton {
   padding: 0.4rem 1rem;
   font-size: 0.9rem;
   font-family: inherit;
   font-weight: 600;
   background: #fff;
-  border: 1.5px solid #ef4444;
+  border: 1.5px solid #ef4444; /* 赤枠でアウトラインスタイルに */
   border-radius: 8px;
-  color: #ef4444;
+  color: #ef4444; /* テキストも赤で危険操作を明示 */
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
 }
 
+/* ホバー時に赤く塗りつぶしてインタラクションを強調 */
 .resetButton:hover {
   background: #ef4444;
   color: #fff;

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest' // afterEach をリセットボタンのスパイ後処理に追加
 import SettingsPage from './SettingsPage'
 
 const mockUpdateDefaultSets = vi.fn()
@@ -130,15 +130,18 @@ describe('SettingsPage', () => {
   })
 })
 
+// データ管理セクション（全データをリセットボタン）のテスト群
 describe('SettingsPage — データ管理セクション', () => {
-  let confirmSpy: ReturnType<typeof vi.spyOn>
-  let localStorageClearSpy: ReturnType<typeof vi.spyOn>
-  let reloadMock: ReturnType<typeof vi.fn>
+  let confirmSpy: ReturnType<typeof vi.spyOn>      // window.confirm のスパイ
+  let localStorageClearSpy: ReturnType<typeof vi.spyOn> // localStorage.clear のスパイ
+  let reloadMock: ReturnType<typeof vi.fn>          // window.location.reload のモック
 
   beforeEach(() => {
-    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false) // デフォルトはキャンセル（false）
+    // jsdom ではインスタンスメソッドのスパイが効かないため Storage.prototype を対象にする
     localStorageClearSpy = vi.spyOn(Storage.prototype, 'clear').mockImplementation(() => {})
     reloadMock = vi.fn()
+    // window.location は読み取り専用のため Object.defineProperty で上書きする
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: { ...window.location, reload: reloadMock },
@@ -146,7 +149,7 @@ describe('SettingsPage — データ管理セクション', () => {
   })
 
   afterEach(() => {
-    confirmSpy.mockRestore()
+    confirmSpy.mockRestore()         // テスト間の汚染を防ぐためスパイを元に戻す
     localStorageClearSpy.mockRestore()
   })
 
@@ -164,28 +167,28 @@ describe('SettingsPage — データ管理セクション', () => {
   })
 
   it('confirm が true を返したとき localStorage.clear が呼ばれる', async () => {
-    confirmSpy.mockReturnValue(true)
+    confirmSpy.mockReturnValue(true) // OK ボタンが押された状態をシミュレート
     render(<SettingsPage />)
     await userEvent.click(screen.getByRole('button', { name: '全データをリセット' }))
     expect(localStorageClearSpy).toHaveBeenCalledTimes(1)
   })
 
   it('confirm が true を返したとき window.location.reload が呼ばれる', async () => {
-    confirmSpy.mockReturnValue(true)
+    confirmSpy.mockReturnValue(true) // OK ボタンが押された状態をシミュレート
     render(<SettingsPage />)
     await userEvent.click(screen.getByRole('button', { name: '全データをリセット' }))
     expect(reloadMock).toHaveBeenCalledTimes(1)
   })
 
   it('confirm が false を返したとき localStorage.clear が呼ばれない', async () => {
-    confirmSpy.mockReturnValue(false)
+    confirmSpy.mockReturnValue(false) // キャンセルが押された状態をシミュレート
     render(<SettingsPage />)
     await userEvent.click(screen.getByRole('button', { name: '全データをリセット' }))
     expect(localStorageClearSpy).not.toHaveBeenCalled()
   })
 
   it('confirm が false を返したとき window.location.reload が呼ばれない', async () => {
-    confirmSpy.mockReturnValue(false)
+    confirmSpy.mockReturnValue(false) // キャンセルが押された状態をシミュレート
     render(<SettingsPage />)
     await userEvent.click(screen.getByRole('button', { name: '全データをリセット' }))
     expect(reloadMock).not.toHaveBeenCalled()

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import SettingsPage from './SettingsPage'
 
 const mockUpdateDefaultSets = vi.fn()
@@ -127,5 +127,67 @@ describe('SettingsPage', () => {
     const selects = screen.getAllByRole('combobox')
     await userEvent.selectOptions(selects[2], '5')
     expect(mockUpdateTrainingDefaultSets).toHaveBeenCalledWith(5)
+  })
+})
+
+describe('SettingsPage — データ管理セクション', () => {
+  let confirmSpy: ReturnType<typeof vi.spyOn>
+  let localStorageClearSpy: ReturnType<typeof vi.spyOn>
+  let reloadMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    localStorageClearSpy = vi.spyOn(Storage.prototype, 'clear').mockImplementation(() => {})
+    reloadMock = vi.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadMock },
+    })
+  })
+
+  afterEach(() => {
+    confirmSpy.mockRestore()
+    localStorageClearSpy.mockRestore()
+  })
+
+  it('「全データをリセット」ボタンが表示される', () => {
+    render(<SettingsPage />)
+    expect(screen.getByRole('button', { name: '全データをリセット' })).toBeInTheDocument()
+  })
+
+  it('ボタンクリックで window.confirm が呼ばれる（メッセージ内容を検証）', async () => {
+    render(<SettingsPage />)
+    await userEvent.click(screen.getByRole('button', { name: '全データをリセット' }))
+    expect(confirmSpy).toHaveBeenCalledWith(
+      '本当にすべてのデータを削除しますか？\nこの操作は元に戻せません。'
+    )
+  })
+
+  it('confirm が true を返したとき localStorage.clear が呼ばれる', async () => {
+    confirmSpy.mockReturnValue(true)
+    render(<SettingsPage />)
+    await userEvent.click(screen.getByRole('button', { name: '全データをリセット' }))
+    expect(localStorageClearSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('confirm が true を返したとき window.location.reload が呼ばれる', async () => {
+    confirmSpy.mockReturnValue(true)
+    render(<SettingsPage />)
+    await userEvent.click(screen.getByRole('button', { name: '全データをリセット' }))
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('confirm が false を返したとき localStorage.clear が呼ばれない', async () => {
+    confirmSpy.mockReturnValue(false)
+    render(<SettingsPage />)
+    await userEvent.click(screen.getByRole('button', { name: '全データをリセット' }))
+    expect(localStorageClearSpy).not.toHaveBeenCalled()
+  })
+
+  it('confirm が false を返したとき window.location.reload が呼ばれない', async () => {
+    confirmSpy.mockReturnValue(false)
+    render(<SettingsPage />)
+    await userEvent.click(screen.getByRole('button', { name: '全データをリセット' }))
+    expect(reloadMock).not.toHaveBeenCalled()
   })
 })

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -10,6 +10,13 @@ export default function SettingsPage() {
     setHeader({ title: '初期値設定', centered: true })
   }, [setHeader])
 
+  function handleResetAllData() {
+    if (window.confirm('本当にすべてのデータを削除しますか？\nこの操作は元に戻せません。')) {
+      localStorage.clear()
+      window.location.reload()
+    }
+  }
+
   return (
     <div className={styles.page}>
       <div className={styles.section}>
@@ -76,6 +83,16 @@ export default function SettingsPage() {
               lbs
             </button>
           </div>
+        </div>
+      </div>
+
+      <div className={`${styles.section} ${styles.dangerSection}`}>
+        <p className={styles.sectionTitle}>データ管理</p>
+        <div className={styles.row}>
+          <span className={styles.label}>全データをリセット</span>
+          <button className={styles.resetButton} onClick={handleResetAllData}>
+            全データをリセット
+          </button>
         </div>
       </div>
     </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -10,10 +10,12 @@ export default function SettingsPage() {
     setHeader({ title: '初期値設定', centered: true })
   }, [setHeader])
 
+  // 全データを削除してアプリを初期状態に戻す処理
   function handleResetAllData() {
+    // ネイティブダイアログで削除前にユーザーへ確認を求める
     if (window.confirm('本当にすべてのデータを削除しますか？\nこの操作は元に戻せません。')) {
-      localStorage.clear()
-      window.location.reload()
+      localStorage.clear() // トレーニング記録・種目リスト・体組成・設定の全データを削除
+      window.location.reload() // ページをリロードしてアプリを初期状態で再起動
     }
   }
 
@@ -86,10 +88,13 @@ export default function SettingsPage() {
         </div>
       </div>
 
+      {/* データ管理セクション：他の設定セクションと視覚的に分離して配置 */}
       <div className={`${styles.section} ${styles.dangerSection}`}>
         <p className={styles.sectionTitle}>データ管理</p>
         <div className={styles.row}>
+          {/* ラベルとリセットボタンを左右に配置 */}
           <span className={styles.label}>全データをリセット</span>
+          {/* クリックで handleResetAllData を呼び出す破壊的操作ボタン */}
           <button className={styles.resetButton} onClick={handleResetAllData}>
             全データをリセット
           </button>


### PR DESCRIPTION
## Summary

- 設定画面の最下部に「データ管理」セクションを新設
- 「全データをリセット」ボタンをクリックすると `window.confirm` で二重確認を求める
- 確認後、`localStorage.clear()` → `window.location.reload()` でアプリを初期状態にリセット
- キャンセル時は何もしない

## Test plan

- [x] 「全データをリセット」ボタンが表示される
- [x] ボタンクリックで `window.confirm` が正しいメッセージで呼ばれる
- [x] confirm が true → `localStorage.clear` が呼ばれる
- [x] confirm が true → `window.location.reload` が呼ばれる
- [x] confirm が false → `localStorage.clear` が呼ばれない
- [x] confirm が false → `window.location.reload` が呼ばれない
- [x] 既存テスト 266件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)