### PR TITLE
fix: Vercel SPA ルーティング設定を追加（リロード時404修正）

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## 原因

React Router はクライアントサイドルーティングを使用しているため、`/history` や `/date/2026-04-25` などのパスは JavaScript が処理する。しかし Vercel はこれらのパスに対応するファイルを持たないため、ページリロード時に **404** を返していた。

「全データをリセット」ボタンが `localStorage.clear()` → `window.location.reload()` を実行するため、空データ状態でリロードした際に特に顕在化していた。

## 修正内容

`vercel.json` を追加し、全パスを `index.html` にリライトするよう設定。

```json
{
  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
}
```

## Test plan

- [x] ビルド成功確認
- [ ] Vercel デプロイ後に `/history`・`/date/:dateStr` 等で直接リロードしても404にならないことを確認
- [ ] 「全データをリセット」ボタン → リロード後も正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)